### PR TITLE
support BOOL type in migration

### DIFF
--- a/Sources/FluentPostgresDriver/PostgresConverterDelegate.swift
+++ b/Sources/FluentPostgresDriver/PostgresConverterDelegate.swift
@@ -5,6 +5,8 @@ struct PostgresConverterDelegate: SQLConverterDelegate {
         switch dataType {
         case .uuid:
             return SQLRaw("UUID")
+        case .bool:
+            return SQLRaw("BOOL")
         default:
             return nil
         }

--- a/Tests/FluentPostgresDriverTests/FluentPostgresDriverTests.swift
+++ b/Tests/FluentPostgresDriverTests/FluentPostgresDriverTests.swift
@@ -112,6 +112,24 @@ final class FluentPostgresDriverTests: XCTestCase {
         try self.benchmarker.testUUIDModel()
     }
 
+    func testSaveModelWithBool() throws {
+        struct Organization: Model {
+            static let shared = Organization()
+            static let entity = "organizations"
+            let id = Field<Int?>("id")
+            let disabled = Field<Bool>("disabled")
+        }
+
+        try Organization.autoMigration().prepare(on: self.connectionPool).wait()
+        defer {
+            try! Organization.autoMigration().revert(on: self.connectionPool).wait()
+        }
+
+        let new = Organization.row()
+        new.disabled = false
+        try new.save(on: self.connectionPool).wait()
+    }
+
     var benchmarker: FluentBenchmarker!
     var connectionPool: ConnectionPool<PostgresConnectionSource>!
     var eventLoopGroup: EventLoopGroup!

--- a/Tests/FluentPostgresDriverTests/XCTestManifests.swift
+++ b/Tests/FluentPostgresDriverTests/XCTestManifests.swift
@@ -27,11 +27,13 @@ extension FluentPostgresDriverTests {
         ("testNestedModel", testNestedModel),
         ("testNullifyField", testNullifyField),
         ("testRead", testRead),
+        ("testSaveModelWithBool", testSaveModelWithBool),
         ("testSoftDelete", testSoftDelete),
         ("testSort", testSort),
         ("testTimestampable", testTimestampable),
         ("testUniqueFields", testUniqueFields),
         ("testUpdate", testUpdate),
+        ("testUUIDModel", testUUIDModel),
     ]
 }
 


### PR DESCRIPTION
Converts Fluent's `.bool` data type to `BOOL` for Postgres.

Fixes: https://github.com/vapor/postgres-nio/issues/34