### PR TITLE
add data -> bytea support

### DIFF
--- a/Sources/FluentPostgresDriver/PostgresConverterDelegate.swift
+++ b/Sources/FluentPostgresDriver/PostgresConverterDelegate.swift
@@ -7,6 +7,8 @@ struct PostgresConverterDelegate: SQLConverterDelegate {
             return SQLRaw("UUID")
         case .bool:
             return SQLRaw("BOOL")
+        case .data:
+            return SQLRaw("BYTEA")
         default:
             return nil
         }

--- a/Tests/FluentPostgresDriverTests/XCTestManifests.swift
+++ b/Tests/FluentPostgresDriverTests/XCTestManifests.swift
@@ -11,6 +11,7 @@ extension FluentPostgresDriverTests {
         ("testAsyncCreate", testAsyncCreate),
         ("testBatchCreate", testBatchCreate),
         ("testBatchUpdate", testBatchUpdate),
+        ("testBlob", testBlob),
         ("testChunkedFetch", testChunkedFetch),
         ("testCreate", testCreate),
         ("testDelete", testDelete),


### PR DESCRIPTION
Adds support for Fluent's `.data` datatype, converting it to `BYTEA`. 

Fixes #119. 