### PR TITLE
Convert Fluent's uint8 type to Postgres "char"

### DIFF
--- a/Sources/FluentPostgresDriver/PostgresConverterDelegate.swift
+++ b/Sources/FluentPostgresDriver/PostgresConverterDelegate.swift
@@ -3,6 +3,8 @@ import FluentSQL
 struct PostgresConverterDelegate: SQLConverterDelegate {
     func customDataType(_ dataType: DatabaseSchema.DataType) -> SQLExpression? {
         switch dataType {
+        case .uint8:
+            return SQLRaw(#""char""#)
         case .uuid:
             return SQLRaw("UUID")
         case .bool:

--- a/Tests/FluentPostgresDriverTests/FluentPostgresDriverTests.swift
+++ b/Tests/FluentPostgresDriverTests/FluentPostgresDriverTests.swift
@@ -167,6 +167,14 @@ final class FluentPostgresDriverTests: XCTestCase {
     func testDuplicatedUniquePropertyName() throws {
         try self.benchmarker.testDuplicatedUniquePropertyName()
     }
+    
+    func testEmptyEagerLoadChildren() throws {
+        try self.benchmarker.testEmptyEagerLoadChildren()
+    }
+    
+    func testUInt8BackedEnum() throws {
+        try self.benchmarker.testUInt8BackedEnum()
+    }
 
     func testBlob() throws {
         final class Foo: Model {


### PR DESCRIPTION
Fluent's `.uint8` schema data type is now converted to Postgres' 8-bit `"char"` type. 