### PR TITLE
Add optional TLSConfiguration parameter to the postgres initializers

### DIFF
--- a/Sources/FluentPostgresDriver/FluentPostgresConfiguration.swift
+++ b/Sources/FluentPostgresDriver/FluentPostgresConfiguration.swift
@@ -3,7 +3,8 @@ extension DatabaseConfigurationFactory {
         url urlString: String,
         maxConnectionsPerEventLoop: Int = 1,
         encoder: PostgresDataEncoder = .init(),
-        decoder: PostgresDataDecoder = .init()
+        decoder: PostgresDataDecoder = .init(),
+        tlsConfiguration: TLSConfiguration? = nil
     ) throws -> DatabaseConfigurationFactory {
         guard let url = URL(string: urlString) else {
             throw FluentPostgresError.invalidURL(urlString)
@@ -20,10 +21,14 @@ extension DatabaseConfigurationFactory {
         url: URL,
         maxConnectionsPerEventLoop: Int = 1,
         encoder: PostgresDataEncoder = .init(),
-        decoder: PostgresDataDecoder = .init()
+        decoder: PostgresDataDecoder = .init(),
+        tlsConfiguration: TLSConfiguration? = nil
     ) throws -> DatabaseConfigurationFactory {
-        guard let configuration = PostgresConfiguration(url: url) else {
+        guard var configuration = PostgresConfiguration(url: url) else {
             throw FluentPostgresError.invalidURL(url.absoluteString)
+        }
+        if let tlsConfiguration = tlsConfiguration {
+            configuration.tlsConfiguration = tlsConfiguration
         }
         return .postgres(
             configuration: configuration,


### PR DESCRIPTION
Some Postgres databases on Heroku need a custom TLS configuration when SSL is required. But the driver does not have a convenient factory to build a `PostgresConfiguration` with only `DATABASE_URL` and the `TLSConfiguration`.

Therefore, I extended the factory functions so be able to perform this:
```swift
let url = URL(string: "https://user:password@host:8080/database")!
let tlsConfiguration = TLSConfiguration.forClient(certificateVerification: .none)
try app.databases.use(.postgres(url: url, tlsConfiguration: tlsConfiguration), as: .psql)
```

relates to https://github.com/vapor/postgres-kit/issues/186