### PR TITLE
Support `.dictionary(of:)` data type

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,18 +1,11 @@
-name: Test Matrix
-
+name: test
 on:
   pull_request:
   push:
     branches:
     - master
-
-defaults:
-  run:
-    shell: bash
-
 jobs:
-
-  Linux:
+  linux:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         .library(name: "FluentPostgresDriver", targets: ["FluentPostgresDriver"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/vapor/fluent-kit.git", from: "1.0.0-rc.2"),
+        .package(url: "https://github.com/vapor/fluent-kit.git", from: "1.0.0-rc.2.7"),
         .package(url: "https://github.com/vapor/postgres-kit.git", from: "2.0.0"),
     ],
     targets: [

--- a/Sources/FluentPostgresDriver/PostgresConverterDelegate.swift
+++ b/Sources/FluentPostgresDriver/PostgresConverterDelegate.swift
@@ -3,27 +3,46 @@ import FluentSQL
 struct PostgresConverterDelegate: SQLConverterDelegate {
     func customDataType(_ dataType: DatabaseSchema.DataType) -> SQLExpression? {
         switch dataType {
-        case .uint8:
-            return SQLRaw(#""char""#)
         case .uuid:
             return SQLRaw("UUID")
         case .bool:
             return SQLRaw("BOOL")
         case .data:
             return SQLRaw("BYTEA")
+        case .date:
+            return SQLRaw("DATE")
         case .datetime:
             return SQLRaw("TIMESTAMPTZ")
         case .double:
             return SQLRaw("DOUBLE PRECISION")
-        case .json:
+        case .dictionary:
             return SQLRaw("JSONB")
+        case .array(of: let type):
+            if let type = type, let dataType = self.customDataType(type) {
+                return SQLArrayDataType(dataType: dataType)
+            } else {
+                return SQLRaw("JSONB")
+            }
         case .enum(let value):
             return SQLIdentifier(value.name)
-        default:
+        case .int8, .uint8:
+            return SQLRaw(#""char""#)
+        case .int16, .uint16:
+            return SQLRaw("SMALLINT")
+        case .int32, .uint32:
+            return SQLRaw("INT")
+        case .int64, .uint64:
+            return SQLRaw("BIGINT")
+        case .string:
+            return SQLRaw("TEXT")
+        case .time:
+            return SQLRaw("TIME")
+        case .float:
+            return SQLRaw("FLOAT")
+        case .custom:
             return nil
         }
     }
-
 
     func nestedFieldExpression(_ column: String, _ path: [String]) -> SQLExpression {
         switch path.count {
@@ -35,5 +54,13 @@ struct PostgresConverterDelegate: SQLConverterDelegate {
         default:
             fatalError()
         }
+    }
+}
+
+private struct SQLArrayDataType: SQLExpression {
+    let dataType: SQLExpression
+    func serialize(to serializer: inout SQLSerializer) {
+        self.dataType.serialize(to: &serializer)
+        serializer.write("[]")
     }
 }

--- a/Tests/FluentPostgresDriverTests/FluentPostgresDriverTests.swift
+++ b/Tests/FluentPostgresDriverTests/FluentPostgresDriverTests.swift
@@ -5,6 +5,8 @@ import XCTest
 
 final class FluentPostgresDriverTests: XCTestCase {
     func testAll() throws { try self.benchmarker.testAll() }
+    
+    #if Xcode
     func testAggregate() throws { try self.benchmarker.testAggregate() }
     func testArray() throws { try self.benchmarker.testArray() }
     func testBatch() throws { try self.benchmarker.testBatch() }
@@ -34,6 +36,7 @@ final class FluentPostgresDriverTests: XCTestCase {
     func testTimestamp() throws { try self.benchmarker.testTimestamp() }
     func testTransaction() throws { try self.benchmarker.testTransaction() }
     func testUnique() throws { try self.benchmarker.testUnique() }
+    #endif
 
     func testDatabaseError() throws {
         let sql = (self.db as! SQLDatabase)


### PR DESCRIPTION
Updates to `.dictionary(of:)` data type added in [FluentKit 1.0.0-rc.2.7](https://github.com/vapor/fluent-kit/releases/tag/1.0.0-rc.2.7) (#156). 