### PR TITLE
Support connection pool timeout configuration

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,11 +10,13 @@ let package = Package(
         .library(name: "FluentPostgresDriver", targets: ["FluentPostgresDriver"]),
     ],
     dependencies: [
+        .package(url: "https://github.com/vapor/async-kit.git", from: "1.2.0"),
         .package(url: "https://github.com/vapor/fluent-kit.git", from: "1.0.0"),
         .package(url: "https://github.com/vapor/postgres-kit.git", from: "2.0.0"),
     ],
     targets: [
         .target(name: "FluentPostgresDriver", dependencies: [
+            .product(name: "AsyncKit", package: "async-kit"),
             .product(name: "FluentKit", package: "fluent-kit"),
             .product(name: "FluentSQL", package: "fluent-kit"),
             .product(name: "PostgresKit", package: "postgres-kit"),

--- a/Sources/FluentPostgresDriver/FluentPostgresConfiguration.swift
+++ b/Sources/FluentPostgresDriver/FluentPostgresConfiguration.swift
@@ -2,7 +2,7 @@ extension DatabaseConfigurationFactory {
     public static func postgres(
         url urlString: String,
         maxConnectionsPerEventLoop: Int = 1,
-        newConnectionTimeout: NIO.TimeAmount = .seconds(10),
+        connectionPoolTimeout: NIO.TimeAmount = .seconds(10),
         encoder: PostgresDataEncoder = .init(),
         decoder: PostgresDataDecoder = .init()
     ) throws -> DatabaseConfigurationFactory {
@@ -12,7 +12,7 @@ extension DatabaseConfigurationFactory {
         return try .postgres(
             url: url,
             maxConnectionsPerEventLoop: maxConnectionsPerEventLoop,
-            newConnectionTimeout: newConnectionTimeout,
+            connectionPoolTimeout: connectionPoolTimeout,
             encoder: encoder,
             decoder: decoder
         )
@@ -21,7 +21,7 @@ extension DatabaseConfigurationFactory {
     public static func postgres(
         url: URL,
         maxConnectionsPerEventLoop: Int = 1,
-        newConnectionTimeout: NIO.TimeAmount = .seconds(10),
+        connectionPoolTimeout: NIO.TimeAmount = .seconds(10),
         encoder: PostgresDataEncoder = .init(),
         decoder: PostgresDataDecoder = .init()
     ) throws -> DatabaseConfigurationFactory {
@@ -31,7 +31,7 @@ extension DatabaseConfigurationFactory {
         return .postgres(
             configuration: configuration,
             maxConnectionsPerEventLoop: maxConnectionsPerEventLoop,
-            newConnectionTimeout: newConnectionTimeout
+            connectionPoolTimeout: connectionPoolTimeout
         )
     }
 
@@ -43,7 +43,7 @@ extension DatabaseConfigurationFactory {
         database: String? = nil,
         tlsConfiguration: TLSConfiguration? = nil,
         maxConnectionsPerEventLoop: Int = 1,
-        newConnectionTimeout: NIO.TimeAmount = .seconds(10),
+        connectionPoolTimeout: NIO.TimeAmount = .seconds(10),
         encoder: PostgresDataEncoder = .init(),
         decoder: PostgresDataDecoder = .init()
     ) -> DatabaseConfigurationFactory {
@@ -57,14 +57,14 @@ extension DatabaseConfigurationFactory {
                 tlsConfiguration: tlsConfiguration
             ),
             maxConnectionsPerEventLoop: maxConnectionsPerEventLoop,
-            newConnectionTimeout: newConnectionTimeout
+            connectionPoolTimeout: connectionPoolTimeout
         )
     }
 
     public static func postgres(
         configuration: PostgresConfiguration,
         maxConnectionsPerEventLoop: Int = 1,
-        newConnectionTimeout: NIO.TimeAmount = .seconds(10),
+        connectionPoolTimeout: NIO.TimeAmount = .seconds(10),
         encoder: PostgresDataEncoder = .init(),
         decoder: PostgresDataDecoder = .init()
     ) -> DatabaseConfigurationFactory {
@@ -73,7 +73,7 @@ extension DatabaseConfigurationFactory {
                 middleware: [],
                 configuration: configuration,
                 maxConnectionsPerEventLoop: maxConnectionsPerEventLoop,
-                newConnectionTimeout: newConnectionTimeout,
+                connectionPoolTimeout: connectionPoolTimeout,
                 encoder: encoder,
                 decoder: decoder
             )
@@ -85,9 +85,9 @@ struct FluentPostgresConfiguration: DatabaseConfiguration {
     var middleware: [AnyModelMiddleware]
     let configuration: PostgresConfiguration
     let maxConnectionsPerEventLoop: Int
-    /// The amount of time to wait for a new connection from
+    /// The amount of time to wait for a connection from
     /// the connection pool before timing out.
-    let newConnectionTimeout: NIO.TimeAmount
+    let connectionPoolTimeout: NIO.TimeAmount
     let encoder: PostgresDataEncoder
     let decoder: PostgresDataDecoder
 
@@ -98,7 +98,7 @@ struct FluentPostgresConfiguration: DatabaseConfiguration {
         let pool = EventLoopGroupConnectionPool(
             source: db,
             maxConnectionsPerEventLoop: maxConnectionsPerEventLoop,
-            requestTimeout: newConnectionTimeout,
+            requestTimeout: connectionPoolTimeout,
             on: databases.eventLoopGroup
         )
         return _FluentPostgresDriver(

--- a/Sources/FluentPostgresDriver/FluentPostgresConfiguration.swift
+++ b/Sources/FluentPostgresDriver/FluentPostgresConfiguration.swift
@@ -2,6 +2,7 @@ extension DatabaseConfigurationFactory {
     public static func postgres(
         url urlString: String,
         maxConnectionsPerEventLoop: Int = 1,
+        newConnectionTimeout: NIO.TimeAmount = .seconds(10),
         encoder: PostgresDataEncoder = .init(),
         decoder: PostgresDataDecoder = .init()
     ) throws -> DatabaseConfigurationFactory {
@@ -11,6 +12,7 @@ extension DatabaseConfigurationFactory {
         return try .postgres(
             url: url,
             maxConnectionsPerEventLoop: maxConnectionsPerEventLoop,
+            newConnectionTimeout: newConnectionTimeout,
             encoder: encoder,
             decoder: decoder
         )
@@ -19,6 +21,7 @@ extension DatabaseConfigurationFactory {
     public static func postgres(
         url: URL,
         maxConnectionsPerEventLoop: Int = 1,
+        newConnectionTimeout: NIO.TimeAmount = .seconds(10),
         encoder: PostgresDataEncoder = .init(),
         decoder: PostgresDataDecoder = .init()
     ) throws -> DatabaseConfigurationFactory {
@@ -27,7 +30,8 @@ extension DatabaseConfigurationFactory {
         }
         return .postgres(
             configuration: configuration,
-            maxConnectionsPerEventLoop: maxConnectionsPerEventLoop
+            maxConnectionsPerEventLoop: maxConnectionsPerEventLoop,
+            newConnectionTimeout: newConnectionTimeout
         )
     }
 
@@ -39,6 +43,7 @@ extension DatabaseConfigurationFactory {
         database: String? = nil,
         tlsConfiguration: TLSConfiguration? = nil,
         maxConnectionsPerEventLoop: Int = 1,
+        newConnectionTimeout: NIO.TimeAmount = .seconds(10),
         encoder: PostgresDataEncoder = .init(),
         decoder: PostgresDataDecoder = .init()
     ) -> DatabaseConfigurationFactory {
@@ -51,13 +56,15 @@ extension DatabaseConfigurationFactory {
                 database: database,
                 tlsConfiguration: tlsConfiguration
             ),
-            maxConnectionsPerEventLoop: maxConnectionsPerEventLoop
+            maxConnectionsPerEventLoop: maxConnectionsPerEventLoop,
+            newConnectionTimeout: newConnectionTimeout
         )
     }
 
     public static func postgres(
         configuration: PostgresConfiguration,
         maxConnectionsPerEventLoop: Int = 1,
+        newConnectionTimeout: NIO.TimeAmount = .seconds(10),
         encoder: PostgresDataEncoder = .init(),
         decoder: PostgresDataDecoder = .init()
     ) -> DatabaseConfigurationFactory {
@@ -66,6 +73,7 @@ extension DatabaseConfigurationFactory {
                 middleware: [],
                 configuration: configuration,
                 maxConnectionsPerEventLoop: maxConnectionsPerEventLoop,
+                newConnectionTimeout: newConnectionTimeout,
                 encoder: encoder,
                 decoder: decoder
             )
@@ -77,6 +85,9 @@ struct FluentPostgresConfiguration: DatabaseConfiguration {
     var middleware: [AnyModelMiddleware]
     let configuration: PostgresConfiguration
     let maxConnectionsPerEventLoop: Int
+    /// The amount of time to wait for a new connection from
+    /// the connection pool before timing out.
+    let newConnectionTimeout: NIO.TimeAmount
     let encoder: PostgresDataEncoder
     let decoder: PostgresDataDecoder
 
@@ -87,6 +98,7 @@ struct FluentPostgresConfiguration: DatabaseConfiguration {
         let pool = EventLoopGroupConnectionPool(
             source: db,
             maxConnectionsPerEventLoop: maxConnectionsPerEventLoop,
+            requestTimeout: newConnectionTimeout,
             on: databases.eventLoopGroup
         )
         return _FluentPostgresDriver(


### PR DESCRIPTION
Allows for configuration of connection pool timeouts (#161). 

The connection pool timeout defines the maximum amount of time allowed for requesting a connection from the pool. This helps to prevent deadlock.

```swift
try app.databases.use(.postgres(
    configuration: ...,
    connectionPoolTimeout: .minutes(1)
), as: .psql)
```

The default timeout is 10 seconds.