### PR TITLE
Add support for configuring using Unix Socket Path

### DIFF
--- a/Sources/FluentPostgresDriver/FluentPostgresConfiguration.swift
+++ b/Sources/FluentPostgresDriver/FluentPostgresConfiguration.swift
@@ -62,6 +62,44 @@ extension DatabaseConfigurationFactory {
     }
 
     public static func postgres(
+        unixDomainSocketPath: String,
+        username: String,
+        maxConnectionsPerEventLoop: Int = 1,
+        connectionPoolTimeout: NIO.TimeAmount = .seconds(10),
+        encoder: PostgresDataEncoder = .init(),
+        decoder: PostgresDataDecoder = .init()
+    ) -> DatabaseConfigurationFactory {
+        let configuration = PostgresConfiguration(unixDomainSocketPath: unixDomainSocketPath,
+                                                  username: username)
+        return .postgres(
+            configuration: configuration,
+            maxConnectionsPerEventLoop: maxConnectionsPerEventLoop,
+            connectionPoolTimeout: connectionPoolTimeout
+        )
+    }
+
+    public static func postgres(
+        unixDomainSocketPath: String,
+        username: String,
+        password: String,
+        database: String? = nil,
+        maxConnectionsPerEventLoop: Int = 1,
+        connectionPoolTimeout: NIO.TimeAmount = .seconds(10),
+        encoder: PostgresDataEncoder = .init(),
+        decoder: PostgresDataDecoder = .init()
+    ) -> DatabaseConfigurationFactory {
+        let configuration = PostgresConfiguration(unixDomainSocketPath: unixDomainSocketPath,
+                                                  username: username,
+                                                  password: password,
+                                                  database: database)
+        return .postgres(
+            configuration: configuration,
+            maxConnectionsPerEventLoop: maxConnectionsPerEventLoop,
+            connectionPoolTimeout: connectionPoolTimeout
+        )
+    }
+
+    public static func postgres(
         configuration: PostgresConfiguration,
         maxConnectionsPerEventLoop: Int = 1,
         connectionPoolTimeout: NIO.TimeAmount = .seconds(10),


### PR DESCRIPTION
Unix domain socket support was added to Postgres-kit in this [PR](https://github.com/vapor/postgres-kit/pull/170) but never made it to the Fluent Driver.

I need it because is the only way to use Cloud SQL from Google Cloud Run.