### PR TITLE
DatabaseConfigurationFactory improvements

### DIFF
--- a/Sources/FluentPostgresDriver/FluentPostgresConfiguration.swift
+++ b/Sources/FluentPostgresDriver/FluentPostgresConfiguration.swift
@@ -31,7 +31,9 @@ extension DatabaseConfigurationFactory {
         return .postgres(
             configuration: configuration,
             maxConnectionsPerEventLoop: maxConnectionsPerEventLoop,
-            connectionPoolTimeout: connectionPoolTimeout
+            connectionPoolTimeout: connectionPoolTimeout,
+            encoder: encoder,
+            decoder: decoder
         )
     }
 
@@ -57,7 +59,9 @@ extension DatabaseConfigurationFactory {
                 tlsConfiguration: tlsConfiguration
             ),
             maxConnectionsPerEventLoop: maxConnectionsPerEventLoop,
-            connectionPoolTimeout: connectionPoolTimeout
+            connectionPoolTimeout: connectionPoolTimeout,
+            encoder: encoder,
+            decoder: decoder
         )
     }
 


### PR DESCRIPTION
Improves DatabaseConfigurationFactory:

- The `encoder` and `decoder` parameters are forwarded in the function `postgres(url:, maxConnectionsPerEventLoop:, connectionPoolTimeout:, encoder:, decoder:)`
- The `encoder` and `decoder` parameters are forwarded in the function `postgres(hostname:, port:,
username:, password:, database:, tlsConfiguration: , maxConnectionsPerEventLoop:, connectionPoolTimeout:, encoder: , decoder:)`
> Note: Previously, those parameters were not being forwarded in those two functions, thus the default `PostgresDataEncoder` and `PostgresDataDecoder` were being used.