### PR TITLE
Updated postgres-kit version to 2.3.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/vapor/async-kit.git", from: "1.2.0"),
         .package(url: "https://github.com/vapor/fluent-kit.git", from: "1.0.0"),
-        .package(url: "https://github.com/vapor/postgres-kit.git", from: "2.0.0"),
+        .package(url: "https://github.com/vapor/postgres-kit.git", from: "2.3.0"),
     ],
     targets: [
         .target(name: "FluentPostgresDriver", dependencies: [


### PR DESCRIPTION
[Release 2.1.1](https://github.com/vapor/fluent-postgres-driver/releases/tag/2.1.1) added `PostgresConfiguration.ianaPortNumber`, but the `Package.swift` still supports versions of `postgres-kit` before `2.3.0`, which is when the property was added.

[postgres-kit Release 2.3.0](https://github.com/vapor/postgres-kit/releases/tag/2.3.0)

Pulling in the `2.1.1` dependency breaks things otherwise, so I believe this should also warrant a `2.1.2` hotfix once merged.

@tanner0101 thoughts?