### PR TITLE
Make SQL Log Level Configurable

### DIFF
--- a/Sources/FluentPostgresDriver/FluentPostgresDatabase.swift
+++ b/Sources/FluentPostgresDriver/FluentPostgresDatabase.swift
@@ -1,4 +1,5 @@
 import FluentSQL
+import Logging
 
 struct _FluentPostgresDatabase {
     let database: PostgresDatabase
@@ -6,6 +7,7 @@ struct _FluentPostgresDatabase {
     let encoder: PostgresDataEncoder
     let decoder: PostgresDataDecoder
     let inTransaction: Bool
+    let sqlLogLevel: Logger.Level
 }
 
 extension _FluentPostgresDatabase: Database {
@@ -89,7 +91,8 @@ extension _FluentPostgresDatabase: Database {
                     context: self.context,
                     encoder: self.encoder,
                     decoder: self.decoder,
-                    inTransaction: true
+                    inTransaction: true,
+                    sqlLogLevel: self.sqlLogLevel
                 )
                 return closure(db).flatMap { result in
                     self.logger.debug("COMMIT")
@@ -113,7 +116,8 @@ extension _FluentPostgresDatabase: Database {
                 context: self.context,
                 encoder: self.encoder,
                 decoder: self.decoder,
-                inTransaction: self.inTransaction
+                inTransaction: self.inTransaction,
+                sqlLogLevel: self.sqlLogLevel
             ))
         }
     }

--- a/Sources/FluentPostgresDriver/FluentPostgresDriver.swift
+++ b/Sources/FluentPostgresDriver/FluentPostgresDriver.swift
@@ -1,3 +1,5 @@
+import Logging
+
 enum FluentPostgresError: Error {
     case invalidURL(String)
 }
@@ -6,6 +8,7 @@ struct _FluentPostgresDriver: DatabaseDriver {
     let pool: EventLoopGroupConnectionPool<PostgresConnectionSource>
     let encoder: PostgresDataEncoder
     let decoder: PostgresDataDecoder
+    let sqlLogLevel: Logger.Level
     
     var eventLoopGroup: EventLoopGroup {
         self.pool.eventLoopGroup
@@ -17,7 +20,8 @@ struct _FluentPostgresDriver: DatabaseDriver {
             context: context,
             encoder: self.encoder,
             decoder: self.decoder,
-            inTransaction: false
+            inTransaction: false,
+            sqlLogLevel: self.sqlLogLevel
         )
     }
     


### PR DESCRIPTION
Adds the option to set the log level at which SQL queries are logged. Defaults to `.debug`.