### PR TITLE
Make `DatabaseError.isConnectionClosed` functional

### DIFF
--- a/Sources/FluentPostgresDriver/PostgresError+Database.swift
+++ b/Sources/FluentPostgresDriver/PostgresError+Database.swift
@@ -53,7 +53,12 @@ extension PostgresError: DatabaseError {
     }
     
     public var isConnectionClosed: Bool {
-        return false
+        switch self {
+        case .connectionClosed:
+            return true
+        default:
+            return false
+        }
     }
     
     public var isConstraintFailure: Bool {


### PR DESCRIPTION
`DatabaseError.isConnectionClosed` now has the value `true` when the underlying error is `PostgresError.connectionClosed`.