### PR TITLE
Bump postgres-kit to 2.5.1

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/vapor/async-kit.git", from: "1.2.0"),
         .package(url: "https://github.com/vapor/fluent-kit.git", from: "1.0.0"),
-        .package(url: "https://github.com/vapor/postgres-kit.git", from: "2.3.0"),
+        .package(url: "https://github.com/vapor/postgres-kit.git", from: "2.5.1"),
     ],
     targets: [
         .target(name: "FluentPostgresDriver", dependencies: [


### PR DESCRIPTION
postgres-kit has been updated to fix build conflicts with swift-nio. This bumps the postgres-kit version to fix build errors.

<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->

<!-- When this PR is merged, the title and body will be -->
<!-- used to generate a release automatically. -->
