### PR TITLE
Support adding multiple enum cases at once

### DIFF
--- a/Sources/FluentPostgresDriver/FluentPostgresDatabase.swift
+++ b/Sources/FluentPostgresDriver/FluentPostgresDatabase.swift
@@ -66,12 +66,13 @@ extension _FluentPostgresDatabase: Database {
             guard !e.createCases.isEmpty else {
                 return self.eventLoop.makeSucceededFuture(())
             }
-            let builder = self.sql().alter(enum: e.name)
-            for create in e.createCases {
-                _ = builder.add(value: create)
-            }
-            self.logger.log(level: self.sqlLogLevel, "\(builder.query)")
-            return builder.run()
+
+            return database.eventLoop.flatten(e.createCases.map { create in
+                let builder = self.sql().alter(enum: e.name)
+                builder.add(value: create)
+                self.logger.log(level: self.sqlLogLevel, "\(builder.query)")
+                return builder.run()
+            })
         case .delete:
             let builder = self.sql().drop(enum: e.name)
             self.logger.log(level: self.sqlLogLevel, "\(builder.query)")


### PR DESCRIPTION
Fixes an issue where updating a table to add multiple new enum cases would only add the last case to the database.

Fixes #189