### PR TITLE
bump target to v12 and swift tools version to 5.5 so it complies with…

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,10 +1,10 @@
-// swift-tools-version:5.2
+// swift-tools-version:5.5
 import PackageDescription
 
 let package = Package(
     name: "fluent-postgres-driver",
     platforms: [
-       .macOS(.v10_15)
+       .macOS(.v12)
     ],
     products: [
         .library(name: "FluentPostgresDriver", targets: ["FluentPostgresDriver"]),


### PR DESCRIPTION
bump target version to 12 and swift tools version to 5.5 so it complies with the concurrency api