### PR TITLE
Explicitly handle a custom ID key set to the empty string

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,15 +15,12 @@ jobs:
           - md5
           - scram-sha-256
         swiftver:
-          - swift:5.2
+          - swift:5.4
           - swift:5.5
           - swift:5.6
           - swiftlang/swift:nightly-main
         swiftos:
           - focal
-        include:
-          - swiftver: swift:5.2
-            test_flag: --enable-test-discovery
     container: ${{ format('{0}-{1}', matrix.swiftver, matrix.swiftos) }}
     runs-on: ubuntu-latest
     env:
@@ -57,8 +54,8 @@ jobs:
     steps:
       - name: Check out package
         uses: actions/checkout@v3
-      - name: Run all tests with Thread Sanitizer
-        run: swift test ${{ matrix.test_flag }} --sanitize=thread
+      - name: Run all tests
+        run: swift test
 
   macos-all:
     strategy:
@@ -69,10 +66,10 @@ jobs:
           - postgresql@14
         dbauth:
           - scram-sha-256
-        xcode:
-          - latest-stable
-          #- latest
-    runs-on: macos-11
+        macos: ['macos-11', 'macos-12']
+        xcode: ['latest-stable', 'latest']
+        exclude: [{ macos: 'macos-11', xcode: 'latest' }]
+    runs-on: ${{ matrix.macos }}
     env:
       LOG_LEVEL: debug
       POSTGRES_HOSTNAME_A: 127.0.0.1
@@ -103,7 +100,5 @@ jobs:
         timeout-minutes: 2
       - name: Checkout code
         uses: actions/checkout@v3
-      - name: Run all tests with Thread Sanitizer
-        run: |
-          swift test --sanitize=thread -Xlinker -rpath \
-                -Xlinker $(xcode-select -p)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-5.5/macosx
+      - name: Run all tests
+        run: swift test

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.2
+// swift-tools-version:5.4
 import PackageDescription
 
 let package = Package(

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/vapor/async-kit.git", from: "1.2.0"),
-        .package(url: "https://github.com/vapor/fluent-kit.git", .branch("composite-primary-key-models")),
+        .package(url: "https://github.com/vapor/fluent-kit.git", from: "1.27.0"),
         .package(url: "https://github.com/vapor/postgres-kit.git", from: "2.5.1"),
     ],
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/vapor/async-kit.git", from: "1.2.0"),
-        .package(url: "https://github.com/vapor/fluent-kit.git", from: "1.0.0"),
+        .package(url: "https://github.com/vapor/fluent-kit.git", .branch("composite-primary-key-models")),
         .package(url: "https://github.com/vapor/postgres-kit.git", from: "2.5.1"),
     ],
     targets: [

--- a/Sources/FluentPostgresDriver/FluentPostgresDatabase.swift
+++ b/Sources/FluentPostgresDriver/FluentPostgresDatabase.swift
@@ -18,7 +18,7 @@ extension _FluentPostgresDatabase: Database {
         var expression = SQLQueryConverter(delegate: PostgresConverterDelegate())
             .convert(query)
         switch query.action {
-        case .create:
+        case .create where query.customIDKey != .string(""):
             expression = PostgresReturningID(
                 base: expression,
                 idKey: query.customIDKey ?? .id

--- a/Tests/FluentPostgresDriverTests/FluentPostgresDriverTests.swift
+++ b/Tests/FluentPostgresDriverTests/FluentPostgresDriverTests.swift
@@ -13,6 +13,7 @@ final class FluentPostgresDriverTests: XCTestCase {
     func testChildren() throws { try self.benchmarker.testChildren() }
     func testChunk() throws { try self.benchmarker.testChunk() }
     func testCodable() throws { try self.benchmarker.testCodable() }
+    func testCompositeID() throws { try self.benchmarker.testCompositeID() }
     func testCRUD() throws { try self.benchmarker.testCRUD() }
     func testEagerLoad() throws { try self.benchmarker.testEagerLoad() }
     func testEnum() throws { try self.benchmarker.testEnum() }


### PR DESCRIPTION
Treat it as meaning not to retrieve an inserted ID value. This is in support of upcoming FluentKit feature work.