### PR TITLE
Add ability to set `inTransaction` flag when configuring a database

### DIFF
--- a/Sources/FluentPostgresDriver/FluentPostgresConfiguration.swift
+++ b/Sources/FluentPostgresDriver/FluentPostgresConfiguration.swift
@@ -7,7 +7,8 @@ extension DatabaseConfigurationFactory {
         connectionPoolTimeout: NIO.TimeAmount = .seconds(10),
         encoder: PostgresDataEncoder = .init(),
         decoder: PostgresDataDecoder = .init(),
-        sqlLogLevel: Logger.Level = .debug
+        sqlLogLevel: Logger.Level = .debug,
+        inTransaction: Bool = false
     ) throws -> DatabaseConfigurationFactory {
         guard let url = URL(string: urlString) else {
             throw FluentPostgresError.invalidURL(urlString)
@@ -18,7 +19,8 @@ extension DatabaseConfigurationFactory {
             connectionPoolTimeout: connectionPoolTimeout,
             encoder: encoder,
             decoder: decoder,
-            sqlLogLevel: sqlLogLevel
+            sqlLogLevel: sqlLogLevel,
+            inTransaction: inTransaction
         )
     }
 
@@ -28,7 +30,8 @@ extension DatabaseConfigurationFactory {
         connectionPoolTimeout: NIO.TimeAmount = .seconds(10),
         encoder: PostgresDataEncoder = .init(),
         decoder: PostgresDataDecoder = .init(),
-        sqlLogLevel: Logger.Level = .debug
+        sqlLogLevel: Logger.Level = .debug,
+        inTransaction: Bool = false
     ) throws -> DatabaseConfigurationFactory {
         guard let configuration = PostgresConfiguration(url: url) else {
             throw FluentPostgresError.invalidURL(url.absoluteString)
@@ -37,7 +40,8 @@ extension DatabaseConfigurationFactory {
             configuration: configuration,
             maxConnectionsPerEventLoop: maxConnectionsPerEventLoop,
             connectionPoolTimeout: connectionPoolTimeout,
-            sqlLogLevel: sqlLogLevel
+            sqlLogLevel: sqlLogLevel,
+            inTransaction: inTransaction
         )
     }
 
@@ -52,7 +56,8 @@ extension DatabaseConfigurationFactory {
         connectionPoolTimeout: NIO.TimeAmount = .seconds(10),
         encoder: PostgresDataEncoder = .init(),
         decoder: PostgresDataDecoder = .init(),
-        sqlLogLevel: Logger.Level = .debug
+        sqlLogLevel: Logger.Level = .debug,
+        inTransaction: Bool = false
     ) -> DatabaseConfigurationFactory {
         return .postgres(
             configuration: .init(
@@ -65,7 +70,8 @@ extension DatabaseConfigurationFactory {
             ),
             maxConnectionsPerEventLoop: maxConnectionsPerEventLoop,
             connectionPoolTimeout: connectionPoolTimeout,
-            sqlLogLevel: sqlLogLevel
+            sqlLogLevel: sqlLogLevel,
+            inTransaction: inTransaction
         )
     }
 
@@ -75,7 +81,8 @@ extension DatabaseConfigurationFactory {
         connectionPoolTimeout: NIO.TimeAmount = .seconds(10),
         encoder: PostgresDataEncoder = .init(),
         decoder: PostgresDataDecoder = .init(),
-        sqlLogLevel: Logger.Level = .debug
+        sqlLogLevel: Logger.Level = .debug,
+        inTransaction: Bool = false
     ) -> DatabaseConfigurationFactory {
         return DatabaseConfigurationFactory {
             FluentPostgresConfiguration(
@@ -85,7 +92,8 @@ extension DatabaseConfigurationFactory {
                 connectionPoolTimeout: connectionPoolTimeout,
                 encoder: encoder,
                 decoder: decoder,
-                sqlLogLevel: sqlLogLevel
+                sqlLogLevel: sqlLogLevel,
+                inTransaction: inTransaction
             )
         }
     }
@@ -101,6 +109,7 @@ struct FluentPostgresConfiguration: DatabaseConfiguration {
     let encoder: PostgresDataEncoder
     let decoder: PostgresDataDecoder
     let sqlLogLevel: Logger.Level
+    let inTransaction: Bool
 
     func makeDriver(for databases: Databases) -> DatabaseDriver {
         let db = PostgresConnectionSource(
@@ -116,7 +125,8 @@ struct FluentPostgresConfiguration: DatabaseConfiguration {
             pool: pool,
             encoder: self.encoder,
             decoder: self.decoder,
-            sqlLogLevel: self.sqlLogLevel
+            sqlLogLevel: self.sqlLogLevel,
+            inTransaction: self.inTransaction
         )
     }
 }

--- a/Sources/FluentPostgresDriver/FluentPostgresDriver.swift
+++ b/Sources/FluentPostgresDriver/FluentPostgresDriver.swift
@@ -9,6 +9,7 @@ struct _FluentPostgresDriver: DatabaseDriver {
     let encoder: PostgresDataEncoder
     let decoder: PostgresDataDecoder
     let sqlLogLevel: Logger.Level
+    let inTransaction: Bool
     
     var eventLoopGroup: EventLoopGroup {
         self.pool.eventLoopGroup
@@ -20,7 +21,7 @@ struct _FluentPostgresDriver: DatabaseDriver {
             context: context,
             encoder: self.encoder,
             decoder: self.decoder,
-            inTransaction: false,
+            inTransaction: inTransaction,
             sqlLogLevel: self.sqlLogLevel
         )
     }

--- a/Tests/FluentPostgresDriverTests/ConfigurationTests.swift
+++ b/Tests/FluentPostgresDriverTests/ConfigurationTests.swift
@@ -1,0 +1,32 @@
+import XCTest
+@testable import FluentPostgresDriver
+
+class ConfigurationTests: XCTestCase {
+    func testSettingTransactionFlag() {
+        let configFactory = DatabaseConfigurationFactory.postgres(configuration: .init(hostname: "hostname", username: "username"), inTransaction: true)
+        
+        let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
+        let threadPool = NIOThreadPool(numberOfThreads: System.coreCount)
+        let dbs = Databases(threadPool: threadPool, on: eventLoopGroup)
+        
+        let driver = configFactory.make().makeDriver(for: dbs)
+        let postgresDriver = driver as! _FluentPostgresDriver
+        XCTAssertTrue(postgresDriver.inTransaction)
+        
+        let configFactory2 = DatabaseConfigurationFactory.postgres(configuration: .init(hostname: "hostname", username: "username"), inTransaction: false)
+        let driver2 = configFactory2.make().makeDriver(for: dbs)
+        let postgresDriver2 = driver2 as! _FluentPostgresDriver
+        XCTAssertFalse(postgresDriver2.inTransaction)
+        
+        let configFactory3 = DatabaseConfigurationFactory.postgres(configuration: .init(hostname: "hostname", username: "username"))
+        let driver3 = configFactory3.make().makeDriver(for: dbs)
+        let postgresDriver3 = driver3 as! _FluentPostgresDriver
+        XCTAssertFalse(postgresDriver3.inTransaction)
+        
+        driver.shutdown()
+        driver2.shutdown()
+        driver3.shutdown()
+        XCTAssertNoThrow(try threadPool.syncShutdownGracefully())
+        XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully())
+    }
+}

--- a/Tests/FluentPostgresDriverTests/FluentPostgresDriverTests.swift
+++ b/Tests/FluentPostgresDriverTests/FluentPostgresDriverTests.swift
@@ -173,7 +173,6 @@ final class FluentPostgresDriverTests: XCTestCase {
         try! EventWithFooMigration().revert(on: self.db).wait()
         try! EnumMigration().revert(on: self.db).wait()
     }
-
     
     var benchmarker: FluentBenchmarker {
         return .init(databases: self.dbs)


### PR DESCRIPTION
This allows you to configure a test database when you manually start and stop transactions outside of Fluent in order to rollback changes in tests without any other code changes to get Fluent queries to work
