### PR TITLE
Require PostgresKit 2.10.1 for CVE-2023-31136 fix

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/vapor/async-kit.git", from: "1.14.0"),
         .package(url: "https://github.com/vapor/fluent-kit.git", from: "1.36.0"),
-        .package(url: "https://github.com/vapor/postgres-kit.git", from: "2.9.0"),
+        .package(url: "https://github.com/vapor/postgres-kit.git", from: "2.10.1"),
     ],
     targets: [
         .target(name: "FluentPostgresDriver", dependencies: [


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->

<!-- When this PR is merged, the title and body will be -->
<!-- used to generate a release automatically. -->
