### PR TITLE
Updated to use new PostgresKit/PostgresNIO APIs

### DIFF
--- a/.api-breakage/allowlist-branch-update-for-new-pnio.txt
+++ b/.api-breakage/allowlist-branch-update-for-new-pnio.txt
@@ -1,0 +1,8 @@
+API breakage: func DatabaseConfigurationFactory.postgres(url:maxConnectionsPerEventLoop:connectionPoolTimeout:encoder:decoder:sqlLogLevel:) has removed default argument from parameter 3
+API breakage: func DatabaseConfigurationFactory.postgres(url:maxConnectionsPerEventLoop:connectionPoolTimeout:encoder:decoder:sqlLogLevel:) has removed default argument from parameter 4
+API breakage: func DatabaseConfigurationFactory.postgres(url:maxConnectionsPerEventLoop:connectionPoolTimeout:encoder:decoder:sqlLogLevel:) has removed default argument from parameter 3
+API breakage: func DatabaseConfigurationFactory.postgres(url:maxConnectionsPerEventLoop:connectionPoolTimeout:encoder:decoder:sqlLogLevel:) has removed default argument from parameter 4
+API breakage: func DatabaseConfigurationFactory.postgres(hostname:port:username:password:database:tlsConfiguration:maxConnectionsPerEventLoop:connectionPoolTimeout:encoder:decoder:sqlLogLevel:) has removed default argument from parameter 8
+API breakage: func DatabaseConfigurationFactory.postgres(hostname:port:username:password:database:tlsConfiguration:maxConnectionsPerEventLoop:connectionPoolTimeout:encoder:decoder:sqlLogLevel:) has removed default argument from parameter 9
+API breakage: func DatabaseConfigurationFactory.postgres(configuration:maxConnectionsPerEventLoop:connectionPoolTimeout:encoder:decoder:sqlLogLevel:) has removed default argument from parameter 3
+API breakage: func DatabaseConfigurationFactory.postgres(configuration:maxConnectionsPerEventLoop:connectionPoolTimeout:encoder:decoder:sqlLogLevel:) has removed default argument from parameter 4

--- a/.github/workflows/projectboard.yml
+++ b/.github/workflows/projectboard.yml
@@ -5,27 +5,7 @@ on:
     types: [reopened, closed, labeled, unlabeled, assigned, unassigned]
 
 jobs:
-  setup_matrix_input:
-    runs-on: ubuntu-latest
-
-    steps:
-      - id: set-matrix 
-        run: |
-          output=$(curl ${{ github.event.issue.url }}/labels | jq '.[] | .name') || output=""
-
-          echo '======================'
-          echo 'Process incoming data'
-          echo '======================'
-          json=$(echo $output | sed 's/"\s"/","/g')
-          echo $json
-          echo "::set-output name=matrix::$(echo $json)"
-    outputs:
-      issueTags: ${{ steps.set-matrix.outputs.matrix }}
-      
-  Manage_project_issues:
-    needs: setup_matrix_input
-    uses: vapor/ci/.github/workflows/issues-to-project-board.yml@main
-    with:
-      labelsJson: ${{ needs.setup_matrix_input.outputs.issueTags }}
-    secrets: 
-      PROJECT_BOARD_AUTOMATION_PAT: "${{ secrets.PROJECT_BOARD_AUTOMATION_PAT }}"
+  update_project_boards:
+    name: Update project boards
+    uses: vapor/ci/.github/workflows/update-project-boards-for-issue.yml@reusable-workflows
+    secrets: inherit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ on:
   push: { branches: ['main'] }
 
 env:
-  LOG_LEVEL: debug
+  LOG_LEVEL: info
   SWIFT_DETERMINISTIC_HASHING: 1
   POSTGRES_HOSTNAME: 'psql-a'
   POSTGRES_HOSTNAME_A: 'psql-a'
@@ -85,7 +85,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - {dbimage: 'postgres:11', dbauth: 'trust',         swiftver: 'swift:5.6-focal'}
+          - {dbimage: 'postgres:11', dbauth: 'trust',         swiftver: 'swift:5.7-focal'}
           - {dbimage: 'postgres:13', dbauth: 'md5',           swiftver: 'swift:5.7-jammy'}
           - {dbimage: 'postgres:15', dbauth: 'scram-sha-256', swiftver: 'swift:5.8-jammy'}
           - {dbimage: 'postgres:15', dbauth: 'scram-sha-256', swiftver: 'swiftlang/swift:nightly-5.9-jammy'}
@@ -159,14 +159,3 @@ jobs:
         uses: actions/checkout@v3
       - name: Run all tests
         run: swift test --sanitize=thread
-
-  test-exports:
-    name: Test exports
-    runs-on: ubuntu-latest
-    container: swift:5.8-jammy
-    steps:
-      - name: Check out Vapor
-        uses: actions/checkout@v3
-        with: { 'fetch-depth': 0 }
-      - name: Build
-        run: swift build -Xswiftc -DBUILDING_DOCC

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
           - dbimage: postgres:15
             dbauth: scram-sha-256
     runs-on: ubuntu-latest
-    container: swift:5.7-jammy
+    container: swift:5.8-jammy
     services:
       psql-a:
         image: ${{ matrix.dbimage }}
@@ -61,11 +61,8 @@ jobs:
       - name: Submit coverage report to Codecov.io
         uses: vapor/swift-codecov-action@v0.2
         with:
-          cc_flags: 'unittests'
           cc_env_vars: 'SWIFT_VERSION,SWIFT_PLATFORM,RUNNER_OS,RUNNER_ARCH,POSTGRES_VERSION,POSTGRES_AUTH_METHOD'
-          cc_fail_ci_if_error: true
-          cc_verbose: true
-          cc_dry_run: false
+          cc_fail_ci_if_error: false
 
   # Check for API breakage versus main
   api-breakage:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -120,7 +120,7 @@ jobs:
         include:
           - dbimage: postgresql@14
             dbauth: scram-sha-256
-            macos: macos-12
+            macos: macos-13
             xcode: latest-stable
     runs-on: ${{ matrix.macos }}
     env:

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.6
+// swift-tools-version:5.7
 import PackageDescription
 
 let package = Package(

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/vapor/async-kit.git", from: "1.14.0"),
         .package(url: "https://github.com/vapor/fluent-kit.git", from: "1.36.0"),
-        .package(url: "https://github.com/vapor/postgres-kit.git", branch: "update-for-new-pnio"),
+        .package(url: "https://github.com/vapor/postgres-kit.git", from: "2.11.0"),
     ],
     targets: [
         .target(name: "FluentPostgresDriver", dependencies: [

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/vapor/async-kit.git", from: "1.14.0"),
         .package(url: "https://github.com/vapor/fluent-kit.git", from: "1.36.0"),
-        .package(url: "https://github.com/vapor/postgres-kit.git", from: "2.10.1"),
+        .package(url: "https://github.com/vapor/postgres-kit.git", branch: "update-for-new-pnio"),
     ],
     targets: [
         .target(name: "FluentPostgresDriver", dependencies: [

--- a/Sources/FluentPostgresDriver/DatabaseID+PostgreSQL.swift
+++ b/Sources/FluentPostgresDriver/DatabaseID+PostgreSQL.swift
@@ -1,0 +1,7 @@
+import FluentKit
+
+extension DatabaseID {
+    public static var psql: DatabaseID {
+        return .init(string: "psql")
+    }
+}

--- a/Sources/FluentPostgresDriver/Deprecations/FluentPostgresConfiguration+Deprecated.swift
+++ b/Sources/FluentPostgresDriver/Deprecations/FluentPostgresConfiguration+Deprecated.swift
@@ -1,0 +1,181 @@
+import Logging
+import FluentKit
+import AsyncKit
+import NIOCore
+import NIOSSL
+import Foundation
+import PostgresKit
+import PostgresNIO
+
+// N.B.: This excessive method duplication is required to maintain the original public API, which allowed defaulting
+// either the encoder, decoder, or both. The "defaulting both" versions now forward to the new API, the others are here.
+
+// Factory methods accepting both encoder and decoder
+extension DatabaseConfigurationFactory {
+    enum FluentPostgresError: Error {
+        case invalidURL(String)
+    }
+
+    @available(*, deprecated, message: "Use `.postgres(url:maxConnectionsPerEventLoop:connectionPoolTimeout:encodingContext:decodingContext:sqlLogLevel:)` instead.")
+    public static func postgres(
+        url: String, maxConnectionsPerEventLoop: Int = 1, connectionPoolTimeout: TimeAmount = .seconds(10),
+        encoder: PostgresDataEncoder, decoder: PostgresDataDecoder, sqlLogLevel: Logger.Level = .debug
+    ) throws -> DatabaseConfigurationFactory {
+        guard let configuration = PostgresConfiguration(url: url) else { throw FluentPostgresError.invalidURL(url) }
+        return .postgres(configuration: configuration,
+            maxConnectionsPerEventLoop: maxConnectionsPerEventLoop, connectionPoolTimeout: connectionPoolTimeout,
+            encoder: encoder, decoder: decoder, sqlLogLevel: sqlLogLevel
+        )
+    }
+
+    @available(*, deprecated, message: "Use `.postgres(url:maxConnectionsPerEventLoop:connectionPoolTimeout:encodingContext:decodingContext:sqlLogLevel:)` instead.")
+    public static func postgres(
+        url: URL, maxConnectionsPerEventLoop: Int = 1, connectionPoolTimeout: TimeAmount = .seconds(10),
+        encoder: PostgresDataEncoder, decoder: PostgresDataDecoder, sqlLogLevel: Logger.Level = .debug
+    ) throws -> DatabaseConfigurationFactory {
+        guard let configuration = PostgresConfiguration(url: url) else { throw FluentPostgresError.invalidURL(url.absoluteString) }
+        return .postgres( configuration: configuration,
+            maxConnectionsPerEventLoop: maxConnectionsPerEventLoop, connectionPoolTimeout: connectionPoolTimeout,
+            encoder: encoder, decoder: decoder, sqlLogLevel: sqlLogLevel
+        )
+    }
+
+    @available(*, deprecated, message: "Use `.postgres(configuration:maxConnectionsPerEventLoop:connectionPoolTimeout:encodingContext:decodingContext:sqlLogLevel:)` instead.")
+    public static func postgres(
+        hostname: String, port: Int = PostgresConfiguration.ianaPortNumber,
+        username: String, password: String, database: String? = nil, tlsConfiguration: TLSConfiguration? = nil,
+        maxConnectionsPerEventLoop: Int = 1, connectionPoolTimeout: TimeAmount = .seconds(10),
+        encoder: PostgresDataEncoder, decoder: PostgresDataDecoder, sqlLogLevel: Logger.Level = .debug
+    ) -> DatabaseConfigurationFactory {
+        .postgres(configuration: .init(
+            hostname: hostname, port: port, username: username, password: password, database: database, tlsConfiguration: tlsConfiguration),
+            maxConnectionsPerEventLoop: maxConnectionsPerEventLoop, connectionPoolTimeout: connectionPoolTimeout,
+            encoder: encoder, decoder: decoder, sqlLogLevel: sqlLogLevel
+        )
+    }
+
+    @available(*, deprecated, message: "Use `.postgres(configuration:maxConnectionsPerEventLoop:connectionPoolTimeout:encodingContext:decodingContext:sqlLogLevel:)` instead.")
+    public static func postgres(
+        configuration: PostgresConfiguration,
+        maxConnectionsPerEventLoop: Int = 1, connectionPoolTimeout: TimeAmount = .seconds(10),
+        encoder: PostgresDataEncoder, decoder: PostgresDataDecoder, sqlLogLevel: Logger.Level = .debug
+    ) -> DatabaseConfigurationFactory {
+        .postgres(
+            configuration: .init(legacyConfiguration: configuration),
+            maxConnectionsPerEventLoop: maxConnectionsPerEventLoop, connectionPoolTimeout: connectionPoolTimeout,
+            encodingContext: .init(jsonEncoder: TypeErasedPostgresJSONEncoder(json: encoder.json)),
+            decodingContext: .init(jsonDecoder: TypeErasedPostgresJSONDecoder(json: decoder.json)),
+            sqlLogLevel: sqlLogLevel
+        )
+    }
+}
+
+// Factory methods accepting only encoder or only decoder.
+extension DatabaseConfigurationFactory {
+    @available(*, deprecated, message: "Use `.postgres(url:maxConnectionsPerEventLoop:connectionPoolTimeout:encodingContext:decodingContext:sqlLogLevel:)` instead.")
+    public static func postgres(
+        url: String, maxConnectionsPerEventLoop: Int = 1, connectionPoolTimeout: TimeAmount = .seconds(10),
+        encoder: PostgresDataEncoder, sqlLogLevel: Logger.Level = .debug
+    ) throws -> DatabaseConfigurationFactory {
+        try .postgres(url: url,
+            maxConnectionsPerEventLoop: maxConnectionsPerEventLoop, connectionPoolTimeout: connectionPoolTimeout,
+            encoder: encoder, decoder: .init(), sqlLogLevel: sqlLogLevel
+        )
+    }
+
+    @available(*, deprecated, message: "Use `.postgres(url:maxConnectionsPerEventLoop:connectionPoolTimeout:encodingContext:decodingContext:sqlLogLevel:)` instead.")
+    public static func postgres(
+        url: String, maxConnectionsPerEventLoop: Int = 1, connectionPoolTimeout: TimeAmount = .seconds(10),
+        decoder: PostgresDataDecoder, sqlLogLevel: Logger.Level = .debug
+    ) throws -> DatabaseConfigurationFactory {
+        try .postgres(url: url,
+            maxConnectionsPerEventLoop: maxConnectionsPerEventLoop, connectionPoolTimeout: connectionPoolTimeout,
+            encoder: .init(), decoder: decoder, sqlLogLevel: sqlLogLevel
+        )
+    }
+
+    @available(*, deprecated, message: "Use `.postgres(url:maxConnectionsPerEventLoop:connectionPoolTimeout:encodingContext:decodingContext:sqlLogLevel:)` instead.")
+    public static func postgres(
+        url: URL, maxConnectionsPerEventLoop: Int = 1, connectionPoolTimeout: TimeAmount = .seconds(10),
+        encoder: PostgresDataEncoder, sqlLogLevel: Logger.Level = .debug
+    ) throws -> DatabaseConfigurationFactory {
+        try .postgres(url: url,
+            maxConnectionsPerEventLoop: maxConnectionsPerEventLoop, connectionPoolTimeout: connectionPoolTimeout,
+            encoder: encoder, decoder: .init(), sqlLogLevel: sqlLogLevel
+        )
+    }
+
+    @available(*, deprecated, message: "Use `.postgres(url:maxConnectionsPerEventLoop:connectionPoolTimeout:encodingContext:decodingContext:sqlLogLevel:)` instead.")
+    public static func postgres(
+        url: URL, maxConnectionsPerEventLoop: Int = 1, connectionPoolTimeout: TimeAmount = .seconds(10),
+        decoder: PostgresDataDecoder, sqlLogLevel: Logger.Level = .debug
+    ) throws -> DatabaseConfigurationFactory {
+        try .postgres(url: url,
+            maxConnectionsPerEventLoop: maxConnectionsPerEventLoop, connectionPoolTimeout: connectionPoolTimeout,
+            encoder: .init(), decoder: decoder, sqlLogLevel: sqlLogLevel
+        )
+    }
+
+    @available(*, deprecated, message: "Use `.postgres(configuration:maxConnectionsPerEventLoop:connectionPoolTimeout:encodingContext:decodingContext:sqlLogLevel:)` instead.")
+    public static func postgres(
+        hostname: String, port: Int = PostgresConfiguration.ianaPortNumber,
+        username: String, password: String, database: String? = nil, tlsConfiguration: TLSConfiguration? = nil,
+        maxConnectionsPerEventLoop: Int = 1, connectionPoolTimeout: TimeAmount = .seconds(10),
+        encoder: PostgresDataEncoder, sqlLogLevel: Logger.Level = .debug
+    ) -> DatabaseConfigurationFactory {
+        .postgres(
+            hostname: hostname, port: port, username: username, password: password, database: database, tlsConfiguration: tlsConfiguration,
+            maxConnectionsPerEventLoop: maxConnectionsPerEventLoop, connectionPoolTimeout: connectionPoolTimeout,
+            encoder: encoder, decoder: .init(), sqlLogLevel: sqlLogLevel
+        )
+    }
+
+    @available(*, deprecated, message: "Use `.postgres(configuration:maxConnectionsPerEventLoop:connectionPoolTimeout:encodingContext:decodingContext:sqlLogLevel:)` instead.")
+    public static func postgres(
+        hostname: String, port: Int = PostgresConfiguration.ianaPortNumber,
+        username: String, password: String, database: String? = nil, tlsConfiguration: TLSConfiguration? = nil,
+        maxConnectionsPerEventLoop: Int = 1, connectionPoolTimeout: TimeAmount = .seconds(10),
+        decoder: PostgresDataDecoder, sqlLogLevel: Logger.Level = .debug
+    ) -> DatabaseConfigurationFactory {
+        .postgres(
+            hostname: hostname, port: port, username: username, password: password, database: database, tlsConfiguration: tlsConfiguration,
+            maxConnectionsPerEventLoop: maxConnectionsPerEventLoop, connectionPoolTimeout: connectionPoolTimeout,
+            encoder: .init(), decoder: decoder, sqlLogLevel: sqlLogLevel
+        )
+    }
+
+    @available(*, deprecated, message: "Use `.postgres(configuration:maxConnectionsPerEventLoop:connectionPoolTimeout:encodingContext:decodingContext:sqlLogLevel:)` instead.")
+    public static func postgres(
+        configuration: PostgresConfiguration, maxConnectionsPerEventLoop: Int = 1, connectionPoolTimeout: TimeAmount = .seconds(10),
+        encoder: PostgresDataEncoder, sqlLogLevel: Logger.Level = .debug
+    ) -> DatabaseConfigurationFactory {
+        .postgres(configuration: configuration,
+            maxConnectionsPerEventLoop: maxConnectionsPerEventLoop, connectionPoolTimeout: connectionPoolTimeout,
+            encoder: encoder, decoder: .init(), sqlLogLevel: sqlLogLevel
+        )
+    }
+
+    @available(*, deprecated, message: "Use `.postgres(configuration:maxConnectionsPerEventLoop:connectionPoolTimeout:encodingContext:decodingContext:sqlLogLevel:)` instead.")
+    public static func postgres(
+        configuration: PostgresConfiguration, maxConnectionsPerEventLoop: Int = 1, connectionPoolTimeout: TimeAmount = .seconds(10),
+        decoder: PostgresDataDecoder, sqlLogLevel: Logger.Level = .debug
+    ) -> DatabaseConfigurationFactory {
+        .postgres(configuration: configuration,
+            maxConnectionsPerEventLoop: maxConnectionsPerEventLoop, connectionPoolTimeout: connectionPoolTimeout,
+            encoder: .init(), decoder: decoder, sqlLogLevel: sqlLogLevel
+        )
+    }
+}
+
+// N.B.: If you change something in these two types, update the copies in PostgresKit too.
+fileprivate struct TypeErasedPostgresJSONDecoder: PostgresJSONDecoder {
+    let json: any PostgresJSONDecoder
+    func decode<T: Decodable>(_: T.Type, from: Data) throws -> T { try self.json.decode(T.self, from: from) }
+    func decode<T: Decodable>(_: T.Type, from: ByteBuffer) throws -> T { try self.json.decode(T.self, from: from) }
+}
+
+fileprivate struct TypeErasedPostgresJSONEncoder: PostgresJSONEncoder {
+    let json: any PostgresJSONEncoder
+    func encode<T: Encodable>(_ value: T) throws -> Data { try self.json.encode(value) }
+    func encode<T: Encodable>(_ value: T, into: inout ByteBuffer) throws { try self.json.encode(value, into: &into) }
+}

--- a/Sources/FluentPostgresDriver/Exports.swift
+++ b/Sources/FluentPostgresDriver/Exports.swift
@@ -1,12 +1,12 @@
-#if !BUILDING_DOCC
+#if swift(>=5.8)
+
+@_documentation(visibility: internal) @_exported import FluentKit
+@_documentation(visibility: internal) @_exported import PostgresKit
+
+#else
 
 @_exported import FluentKit
 @_exported import PostgresKit
-
-#else 
-
-import FluentKit
-import PostgresKit
 
 #endif
 

--- a/Sources/FluentPostgresDriver/Exports.swift
+++ b/Sources/FluentPostgresDriver/Exports.swift
@@ -10,8 +10,3 @@
 
 #endif
 
-extension DatabaseID {
-    public static var psql: DatabaseID {
-        return .init(string: "psql")
-    }
-}

--- a/Sources/FluentPostgresDriver/FluentPostgresConfiguration.swift
+++ b/Sources/FluentPostgresDriver/FluentPostgresConfiguration.swift
@@ -5,123 +5,116 @@ import NIOCore
 import NIOSSL
 import Foundation
 import PostgresKit
+import PostgresNIO
 
 extension DatabaseConfigurationFactory {
+    /// Create a PostgreSQL database configuration from a URL string.
+    ///
+    /// See ``PostgresKit/SQLPostgresConfiguration/init(url:)`` for the allowed URL format.
+    ///
+    /// - Parameters:
+    ///   - urlString: The URL describing the connection, as a string.
+    ///   - maxConnectionsPerEventLoop: Maximum number of connections to open per event loop.
+    ///   - connectionPoolTimeout: Maximum time to wait for a connection to become available per request.
+    ///   - encodingContext: Encoding context to use for serializing data.
+    ///   - decodingContext: Decoding context to use for deserializing data.
+    ///   - sqlLogLevel: Level at which to log SQL queries.
     public static func postgres(
         url urlString: String,
         maxConnectionsPerEventLoop: Int = 1,
         connectionPoolTimeout: TimeAmount = .seconds(10),
-        encoder: PostgresDataEncoder = .init(),
-        decoder: PostgresDataDecoder = .init(),
+        encodingContext: PostgresEncodingContext<some PostgresJSONEncoder> = .default,
+        decodingContext: PostgresDecodingContext<some PostgresJSONDecoder> = .default,
         sqlLogLevel: Logger.Level = .debug
     ) throws -> DatabaseConfigurationFactory {
-        guard let url = URL(string: urlString) else {
-            throw FluentPostgresError.invalidURL(urlString)
-        }
-        return try .postgres(
-            url: url,
+        .postgres(
+            configuration: try .init(url: urlString),
             maxConnectionsPerEventLoop: maxConnectionsPerEventLoop,
             connectionPoolTimeout: connectionPoolTimeout,
-            encoder: encoder,
-            decoder: decoder,
+            encodingContext: encodingContext, decodingContext: decodingContext,
             sqlLogLevel: sqlLogLevel
         )
     }
 
+    /// Create a PostgreSQL database configuration from a URL.
+    ///
+    /// See ``PostgresKit/SQLPostgresConfiguration/init(url:)`` for the allowed URL format.
+    ///
+    /// - Parameters:
+    ///   - url: The URL describing the connection.
+    ///   - maxConnectionsPerEventLoop: Maximum number of connections to open per event loop.
+    ///   - connectionPoolTimeout: Maximum time to wait for a connection to become available per request.
+    ///   - encodingContext: Encoding context to use for serializing data.
+    ///   - decodingContext: Decoding context to use for deserializing data.
+    ///   - sqlLogLevel: Level at which to log SQL queries.
     public static func postgres(
         url: URL,
         maxConnectionsPerEventLoop: Int = 1,
         connectionPoolTimeout: TimeAmount = .seconds(10),
-        encoder: PostgresDataEncoder = .init(),
-        decoder: PostgresDataDecoder = .init(),
+        encodingContext: PostgresEncodingContext<some PostgresJSONEncoder> = .default,
+        decodingContext: PostgresDecodingContext<some PostgresJSONDecoder> = .default,
         sqlLogLevel: Logger.Level = .debug
     ) throws -> DatabaseConfigurationFactory {
-        guard let configuration = PostgresConfiguration(url: url) else {
-            throw FluentPostgresError.invalidURL(url.absoluteString)
-        }
-        return .postgres(
-            configuration: configuration,
+        .postgres(
+            configuration: try .init(url: url),
             maxConnectionsPerEventLoop: maxConnectionsPerEventLoop,
             connectionPoolTimeout: connectionPoolTimeout,
+            encodingContext: encodingContext, decodingContext: decodingContext,
             sqlLogLevel: sqlLogLevel
         )
     }
 
+    /// Create a PostgreSQL database configuration from lower-level configuration.
+    ///
+    /// - Parameters:
+    ///   - configuration: A ``PostgresKit/SQLPostgresConfiguration`` describing the connection.
+    ///   - maxConnectionsPerEventLoop: Maximum number of connections to open per event loop.
+    ///   - connectionPoolTimeout: Maximum time to wait for a connection to become available per request.
+    ///   - encodingContext: Encoding context to use for serializing data.
+    ///   - decodingContext: Decoding context to use for deserializing data.
+    ///   - sqlLogLevel: Level at which to log SQL queries.
     public static func postgres(
-        hostname: String,
-        port: Int = PostgresConfiguration.ianaPortNumber,
-        username: String,
-        password: String,
-        database: String? = nil,
-        tlsConfiguration: TLSConfiguration? = nil,
+        configuration: SQLPostgresConfiguration,
         maxConnectionsPerEventLoop: Int = 1,
         connectionPoolTimeout: TimeAmount = .seconds(10),
-        encoder: PostgresDataEncoder = .init(),
-        decoder: PostgresDataDecoder = .init(),
+        encodingContext: PostgresEncodingContext<some PostgresJSONEncoder> = .default,
+        decodingContext: PostgresDecodingContext<some PostgresJSONDecoder> = .default,
         sqlLogLevel: Logger.Level = .debug
     ) -> DatabaseConfigurationFactory {
-        return .postgres(
-            configuration: .init(
-                hostname: hostname,
-                port: port,
-                username: username,
-                password: password,
-                database: database,
-                tlsConfiguration: tlsConfiguration
-            ),
-            maxConnectionsPerEventLoop: maxConnectionsPerEventLoop,
-            connectionPoolTimeout: connectionPoolTimeout,
-            sqlLogLevel: sqlLogLevel
-        )
-    }
-
-    public static func postgres(
-        configuration: PostgresConfiguration,
-        maxConnectionsPerEventLoop: Int = 1,
-        connectionPoolTimeout: TimeAmount = .seconds(10),
-        encoder: PostgresDataEncoder = .init(),
-        decoder: PostgresDataDecoder = .init(),
-        sqlLogLevel: Logger.Level = .debug
-    ) -> DatabaseConfigurationFactory {
-        return DatabaseConfigurationFactory {
+        .init {
             FluentPostgresConfiguration(
-                middleware: [],
                 configuration: configuration,
                 maxConnectionsPerEventLoop: maxConnectionsPerEventLoop,
                 connectionPoolTimeout: connectionPoolTimeout,
-                encoder: encoder,
-                decoder: decoder,
+                encodingContext: encodingContext, decodingContext: decodingContext,
                 sqlLogLevel: sqlLogLevel
             )
         }
     }
 }
 
-struct FluentPostgresConfiguration: DatabaseConfiguration {
-    var middleware: [AnyModelMiddleware]
-    let configuration: PostgresConfiguration
+struct FluentPostgresConfiguration<E: PostgresJSONEncoder, D: PostgresJSONDecoder>: DatabaseConfiguration {
+    var middleware: [any AnyModelMiddleware] = []
+    let configuration: SQLPostgresConfiguration
     let maxConnectionsPerEventLoop: Int
-    /// The amount of time to wait for a connection from
-    /// the connection pool before timing out.
     let connectionPoolTimeout: TimeAmount
-    let encoder: PostgresDataEncoder
-    let decoder: PostgresDataDecoder
+    let encodingContext: PostgresEncodingContext<E>
+    let decodingContext: PostgresDecodingContext<D>
     let sqlLogLevel: Logger.Level
 
-    func makeDriver(for databases: Databases) -> DatabaseDriver {
-        let db = PostgresConnectionSource(
-            configuration: configuration
-        )
-        let pool = EventLoopGroupConnectionPool(
-            source: db,
-            maxConnectionsPerEventLoop: maxConnectionsPerEventLoop,
-            requestTimeout: connectionPoolTimeout,
+    func makeDriver(for databases: Databases) -> any DatabaseDriver {
+        let connectionSource = PostgresConnectionSource(sqlConfiguration: self.configuration)
+        let elgPool = EventLoopGroupConnectionPool(
+            source: connectionSource,
+            maxConnectionsPerEventLoop: self.maxConnectionsPerEventLoop,
+            requestTimeout: self.connectionPoolTimeout,
             on: databases.eventLoopGroup
         )
+        
         return _FluentPostgresDriver(
-            pool: pool,
-            encoder: self.encoder,
-            decoder: self.decoder,
+            pool: elgPool,
+            encodingContext: self.encodingContext,
+            decodingContext: self.decodingContext,
             sqlLogLevel: self.sqlLogLevel
         )
     }

--- a/Sources/FluentPostgresDriver/FluentPostgresDatabase.swift
+++ b/Sources/FluentPostgresDriver/FluentPostgresDatabase.swift
@@ -5,64 +5,43 @@ import PostgresKit
 import PostgresNIO
 import SQLKit
 
-struct _FluentPostgresDatabase {
-    let database: PostgresDatabase
+struct _FluentPostgresDatabase<E: PostgresJSONEncoder, D: PostgresJSONDecoder> {
+    let database: any SQLDatabase
     let context: DatabaseContext
-    let encoder: PostgresDataEncoder
-    let decoder: PostgresDataDecoder
+    let encodingContext: PostgresEncodingContext<E>
+    let decodingContext: PostgresDecodingContext<D>
     let inTransaction: Bool
-    let sqlLogLevel: Logger.Level
 }
 
 extension _FluentPostgresDatabase: Database {
     func execute(
         query: DatabaseQuery,
-        onOutput: @escaping (DatabaseOutput) -> ()
+        onOutput: @escaping (any DatabaseOutput) -> ()
     ) -> EventLoopFuture<Void> {
-        var expression = SQLQueryConverter(delegate: PostgresConverterDelegate())
-            .convert(query)
-        switch query.action {
-        case .create where query.customIDKey != .string(""):
-            expression = PostgresReturningID(
-                base: expression,
-                idKey: query.customIDKey ?? .id
-            )
-        default: break
+        var expression = SQLQueryConverter(delegate: PostgresConverterDelegate()).convert(query)
+        
+        /// For `.create` query actions, we want to return the generated IDs, unless the `customIDKey` is the
+        /// empty string, which we use as a very hacky signal for "we don't implement this for composite IDs yet".
+        if case .create = query.action, query.customIDKey != .some(.string("")) {
+            expression = PostgresReturningID(base: expression, idKey: query.customIDKey ?? .id)
         }
-        let (sql, binds) = self.serialize(expression)
-        self.logger.log(level: self.sqlLogLevel, "\(sql) \(binds)")
-        do {
-            return try self.query(sql, binds.map { try self.encoder.encode($0) }) {
-                onOutput($0.databaseOutput(using: self.decoder))
-            }
-        } catch {
-            return self.eventLoop.makeFailedFuture(error)
-        }
+        
+        return self.execute(sql: expression, { onOutput($0.databaseOutput()) })
     }
 
     func execute(schema: DatabaseSchema) -> EventLoopFuture<Void> {
-        let expression = SQLSchemaConverter(delegate: PostgresConverterDelegate())
-            .convert(schema)
-        let (sql, binds) = self.serialize(expression)
-        self.logger.log(level: self.sqlLogLevel, "\(sql) \(binds)")
-        do {
-            return try self.query(sql, binds.map { try self.encoder.encode($0) }) {
-                fatalError("unexpected row: \($0)")
-            }
-        } catch {
-            return self.eventLoop.makeFailedFuture(error)
-        }
+        let expression = SQLSchemaConverter(delegate: PostgresConverterDelegate()).convert(schema)
+
+        return self.execute(sql: expression,
+            // N.B.: Don't fatalError() here; what're users supposed to do about it?
+            { self.logger.error("Unexpected row returned from schema query: \($0)") }
+        )
     }
 
     func execute(enum e: DatabaseEnum) -> EventLoopFuture<Void> {
         switch e.action {
         case .create:
-            let builder = self.create(enum: e.name)
-            for c in e.createCases {
-                _ = builder.value(c)
-            }
-            self.logger.log(level: self.sqlLogLevel, "\(builder.query)")
-            return builder.run()
+            return e.createCases.reduce(self.create(enum: e.name)) { $0.value($1) }.run()
         case .update:
             if !e.deleteCases.isEmpty {
                 self.logger.error("PostgreSQL does not support deleting enum cases.")
@@ -71,58 +50,43 @@ extension _FluentPostgresDatabase: Database {
                 return self.eventLoop.makeSucceededFuture(())
             }
 
-            return database.eventLoop.flatten(e.createCases.map { create in
-                let builder = self.alter(enum: e.name)
-                builder.add(value: create)
-                self.logger.log(level: self.sqlLogLevel, "\(builder.query)")
-                return builder.run()
+            return self.eventLoop.flatten(e.createCases.map { create in
+                self.alter(enum: e.name).add(value: create).run()
             })
         case .delete:
-            let builder = self.drop(enum: e.name)
-            self.logger.log(level: self.sqlLogLevel, "\(builder.query)")
-            return builder.run()
+            return self.drop(enum: e.name).run()
         }
     }
 
-    func transaction<T>(_ closure: @escaping (Database) -> EventLoopFuture<T>) -> EventLoopFuture<T> {
+    func transaction<T>(_ closure: @escaping (any Database) -> EventLoopFuture<T>) -> EventLoopFuture<T> {
         guard !self.inTransaction else {
             return closure(self)
         }
-        return self.database.withConnection { conn in
-            self.logger.log(level: self.sqlLogLevel, "BEGIN")
-            return conn.simpleQuery("BEGIN").flatMap { _ in
-                let db = _FluentPostgresDatabase(
-                    database: conn,
-                    context: self.context,
-                    encoder: self.encoder,
-                    decoder: self.decoder,
-                    inTransaction: true,
-                    sqlLogLevel: self.sqlLogLevel
-                )
-                return closure(db).flatMap { result in
-                    self.logger.log(level: self.sqlLogLevel, "COMMIT")
-                    return conn.simpleQuery("COMMIT").map { _ in
-                        result
-                    }
+        return self.withConnection { conn in
+            guard let sqlConn = conn as? any SQLDatabase else {
+                fatalError("""
+                    Connection yieled by a Fluent+Postgres database is not also an SQLDatabase.
+                    This is a bug in Fluent; please report it at https://github.com/vapor/fluent-postgres-driver/issues
+                    """)
+            }
+            return sqlConn.raw("BEGIN").run().flatMap {
+                return closure(conn).flatMap { result in
+                    sqlConn.raw("COMMIT").run().map { result }
                 }.flatMapError { error in
-                    self.logger.log(level: self.sqlLogLevel, "ROLLBACK")
-                    return conn.simpleQuery("ROLLBACK").flatMapThrowing { _ in
-                        throw error
-                    }
+                    sqlConn.raw("ROLLBACK").run().flatMapThrowing { throw error }
                 }
             }
         }
     }
     
-    func withConnection<T>(_ closure: @escaping (Database) -> EventLoopFuture<T>) -> EventLoopFuture<T> {
-        self.database.withConnection {
+    func withConnection<T>(_ closure: @escaping (any Database) -> EventLoopFuture<T>) -> EventLoopFuture<T> {
+        self.withConnection { (underlying: any PostgresDatabase) in
             closure(_FluentPostgresDatabase(
-                database: $0,
+                database: underlying.sql(encodingContext: self.encodingContext, decodingContext: self.decodingContext, queryLogLevel: self.database.queryLogLevel),
                 context: self.context,
-                encoder: self.encoder,
-                decoder: self.decoder,
-                inTransaction: self.inTransaction,
-                sqlLogLevel: self.sqlLogLevel
+                encodingContext: self.encodingContext,
+                decodingContext: self.decodingContext,
+                inTransaction: true
             ))
         }
     }
@@ -130,61 +94,53 @@ extension _FluentPostgresDatabase: Database {
 
 extension _FluentPostgresDatabase: TransactionControlDatabase {
     func beginTransaction() -> EventLoopFuture<Void> {
-        self.database.withConnection { conn in
-            self.logger.log(level: self.sqlLogLevel, "BEGIN")
-            return conn.simpleQuery("BEGIN").map { _ in }
-        }
+        self.raw("BEGIN").run()
     }
     
-    func commitTransaction() -> NIOCore.EventLoopFuture<Void> {
-        self.database.withConnection { conn in
-            self.logger.log(level: self.sqlLogLevel, "COMMIT")
-            return conn.simpleQuery("COMMIT").map { _ in }
-        }
+    func commitTransaction() -> EventLoopFuture<Void> {
+        self.raw("COMMIT").run()
     }
     
-    func rollbackTransaction() -> NIOCore.EventLoopFuture<Void> {
-        self.database.withConnection { conn in
-            self.logger.log(level: self.sqlLogLevel, "ROLLBACK")
-            return conn.simpleQuery("ROLLBACK").map { _ in }
-        }
+    func rollbackTransaction() -> EventLoopFuture<Void> {
+        self.raw("ROLLBACK").run()
     }
 }
 
 extension _FluentPostgresDatabase: SQLDatabase {
-    var dialect: SQLDialect {
-        PostgresDialect()
-    }
+    var version: (any SQLDatabaseReportedVersion)? { self.database.version }
+    var dialect: any SQLDialect { self.database.dialect }
+    var queryLogLevel: Logger.Level? { self.database.queryLogLevel }
     
-    public func execute(
-        sql query: SQLExpression,
-        _ onRow: @escaping (SQLRow) -> ()
-    ) -> EventLoopFuture<Void> {
-        let (sql, binds) = self.serialize(query)
-        self.logger.log(level: self.sqlLogLevel, "\(sql) \(binds)")
-        return self.sql(encoder: encoder, decoder: decoder).execute(sql: query, onRow)
+    func execute(sql query: any SQLExpression, _ onRow: @escaping (any SQLRow) -> ()) -> EventLoopFuture<Void> {
+        self.database.execute(sql: query, onRow)
     }
 }
 
 extension _FluentPostgresDatabase: PostgresDatabase {
-    func send(_ request: PostgresRequest, logger: Logger) -> EventLoopFuture<Void> {
-        self.database.send(request, logger: logger)
+    func send(_ request: any PostgresRequest, logger: Logger) -> EventLoopFuture<Void> {
+        self.withConnection { $0.send(request, logger: logger) }
     }
     
     func withConnection<T>(_ closure: @escaping (PostgresConnection) -> EventLoopFuture<T>) -> EventLoopFuture<T> {
-        self.database.withConnection(closure)
+        guard let psqlDb: any PostgresDatabase = self.database as? any PostgresDatabase else {
+            fatalError("""
+                Connection yieled by a Fluent+Postgres database is not also a PostgresDatabase.
+                This is a bug in Fluent; please report it at https://github.com/vapor/fluent-postgres-driver/issues
+                """)
+        }
+        
+        return psqlDb.withConnection(closure)
     }
 }
 
 private struct PostgresReturningID: SQLExpression {
-    let base: SQLExpression
+    let base: any SQLExpression
     let idKey: FieldKey
 
     func serialize(to serializer: inout SQLSerializer) {
         serializer.statement {
             $0.append(self.base)
-            $0.append("RETURNING")
-            $0.append(SQLIdentifier(self.idKey.description))
+            $0.append("RETURNING", SQLIdentifier(self.idKey.description))
         }
     }
 }

--- a/Sources/FluentPostgresDriver/FluentPostgresDriver.swift
+++ b/Sources/FluentPostgresDriver/FluentPostgresDriver.swift
@@ -4,28 +4,22 @@ import Logging
 import FluentKit
 import PostgresKit
 
-enum FluentPostgresError: Error {
-    case invalidURL(String)
-}
-
-struct _FluentPostgresDriver: DatabaseDriver {
+struct _FluentPostgresDriver<E: PostgresJSONEncoder, D: PostgresJSONDecoder>: DatabaseDriver {
     let pool: EventLoopGroupConnectionPool<PostgresConnectionSource>
-    let encoder: PostgresDataEncoder
-    let decoder: PostgresDataDecoder
+    let encodingContext: PostgresEncodingContext<E>
+    let decodingContext: PostgresDecodingContext<D>
     let sqlLogLevel: Logger.Level
     
-    var eventLoopGroup: EventLoopGroup {
-        self.pool.eventLoopGroup
-    }
-    
-    func makeDatabase(with context: DatabaseContext) -> Database {
+    func makeDatabase(with context: DatabaseContext) -> any Database {
         _FluentPostgresDatabase(
-            database: self.pool.pool(for: context.eventLoop).database(logger: context.logger),
+            database: self.pool
+                .pool(for: context.eventLoop)
+                .database(logger: context.logger)
+                .sql(encodingContext: self.encodingContext, decodingContext: self.decodingContext, queryLogLevel: self.sqlLogLevel),
             context: context,
-            encoder: self.encoder,
-            decoder: self.decoder,
-            inTransaction: false,
-            sqlLogLevel: self.sqlLogLevel
+            encodingContext: self.encodingContext,
+            decodingContext: self.decodingContext,
+            inTransaction: false
         )
     }
     

--- a/Sources/FluentPostgresDriver/PostgresConverterDelegate.swift
+++ b/Sources/FluentPostgresDriver/PostgresConverterDelegate.swift
@@ -3,7 +3,7 @@ import FluentSQL
 import SQLKit
 
 struct PostgresConverterDelegate: SQLConverterDelegate {
-    func customDataType(_ dataType: DatabaseSchema.DataType) -> SQLExpression? {
+    func customDataType(_ dataType: DatabaseSchema.DataType) -> (any SQLExpression)? {
         switch dataType {
         case .uuid:
             return SQLRaw("UUID")
@@ -28,7 +28,7 @@ struct PostgresConverterDelegate: SQLConverterDelegate {
         case .enum(let value):
             return SQLIdentifier(value.name)
         case .int8, .uint8:
-            return SQLRaw(#""char""#)
+            return SQLIdentifier("char")
         case .int16, .uint16:
             return SQLRaw("SMALLINT")
         case .int32, .uint32:
@@ -46,7 +46,7 @@ struct PostgresConverterDelegate: SQLConverterDelegate {
         }
     }
 
-    func nestedFieldExpression(_ column: String, _ path: [String]) -> SQLExpression {
+    func nestedFieldExpression(_ column: String, _ path: [String]) -> any SQLExpression {
         switch path.count {
         case 1:
             return SQLRaw("\(column)->>'\(path[0])'")
@@ -60,7 +60,8 @@ struct PostgresConverterDelegate: SQLConverterDelegate {
 }
 
 private struct SQLArrayDataType: SQLExpression {
-    let dataType: SQLExpression
+    let dataType: any SQLExpression
+    
     func serialize(to serializer: inout SQLSerializer) {
         self.dataType.serialize(to: &serializer)
         serializer.write("[]")

--- a/Sources/FluentPostgresDriver/PostgresRow+Database.swift
+++ b/Sources/FluentPostgresDriver/PostgresRow+Database.swift
@@ -3,83 +3,17 @@ import PostgresKit
 import FluentKit
 import SQLKit
 
-extension PostgresRow {
-    internal func databaseOutput(using decoder: PostgresDataDecoder) -> DatabaseOutput {
-        _PostgresDatabaseOutput(
-            row: self,
-            decoder: decoder
-        )
-    }
+extension SQLRow {
+    internal func databaseOutput() -> some DatabaseOutput { _PostgresDatabaseOutput(row: self, schema: nil) }
 }
 
 private struct _PostgresDatabaseOutput: DatabaseOutput {
-    let row: SQLRow
-    
-    init(row: PostgresRow, decoder: PostgresDataDecoder) {
-        self.row = row.sql(decoder: decoder)
-    }
-    
-    var description: String {
-        String(describing: self.row)
-    }
-
-    func schema(_ schema: String) -> DatabaseOutput {
-        _SchemaDatabaseOutput(output: self, schema: schema)
-    }
-
-    func contains(_ key: FieldKey) -> Bool {
-        self.row.contains(column: self.columnName(key))
-    }
-
-    func decodeNil(_ key: FieldKey) throws -> Bool {
-        try self.row.decodeNil(column: self.columnName(key))
-    }
-
-    func decode<T>(_ key: FieldKey, as type: T.Type) throws -> T where T: Decodable {
-        try self.row.decode(column: self.columnName(key), as: T.self)
-    }
-
-    private func columnName(_ key: FieldKey) -> String {
-        switch key {
-        case .id:
-            return "id"
-        case .aggregate:
-            return key.description
-        case .string(let name):
-            return name
-        case .prefix(let prefix, let key):
-            return self.columnName(prefix) + self.columnName(key)
-        }
-    }
-}
-
-private struct _SchemaDatabaseOutput: DatabaseOutput {
-    let output: DatabaseOutput
-    let schema: String
-
-    var description: String {
-        self.output.description
-    }
-
-    func schema(_ schema: String) -> DatabaseOutput {
-        self.output.schema(schema)
-    }
-
-    func contains(_ key: FieldKey) -> Bool {
-        self.output.contains(self.key(key))
-    }
-
-    func decodeNil(_ key: FieldKey) throws -> Bool {
-        try self.output.decodeNil(self.key(key))
-    }
-
-    func decode<T>(_ key: FieldKey, as type: T.Type) throws -> T
-        where T: Decodable
-    {
-        try self.output.decode(self.key(key), as: T.self)
-    }
-
-    private func key(_ key: FieldKey) -> FieldKey {
-        .prefix(.string(self.schema + "_"), key)
-    }
+    let row: any SQLRow
+    let schema: String?
+    var description: String { String(describing: self.row) }
+    private func adjust(key: FieldKey) -> FieldKey { self.schema.map { .prefix(.prefix(.string($0), "_"), key) } ?? key }
+    func schema(_ schema: String) -> any DatabaseOutput { _PostgresDatabaseOutput(row: self.row, schema: schema) }
+    func contains(_ key: FieldKey) -> Bool { self.row.contains(column: self.adjust(key: key).description) }
+    func decodeNil(_ key: FieldKey) throws -> Bool { try self.row.decodeNil(column: self.adjust(key: key).description) }
+    func decode<T: Decodable>(_ key: FieldKey, as: T.Type) throws -> T { try self.row.decode(column: self.adjust(key: key).description, as: T.self) }
 }

--- a/Tests/FluentPostgresDriverTests/FluentPostgresDriverTests.swift
+++ b/Tests/FluentPostgresDriverTests/FluentPostgresDriverTests.swift
@@ -40,7 +40,7 @@ final class FluentPostgresDriverTests: XCTestCase {
     func testUnique() throws { try self.benchmarker.testUnique() }
 
     func testDatabaseError() throws {
-        let sql = (self.db as! SQLDatabase)
+        let sql = (self.db as! any SQLDatabase)
         do {
             try sql.raw("asd").run().wait()
         } catch let error as DatabaseError where error.isSyntaxError {
@@ -61,15 +61,15 @@ final class FluentPostgresDriverTests: XCTestCase {
     
     func testBlob() throws {
         struct CreateFoo: Migration {
-            func prepare(on database: Database) -> EventLoopFuture<Void> {
-                return database.schema("foos")
+            func prepare(on database: any Database) -> EventLoopFuture<Void> {
+                database.schema("foos")
                     .field("id", .int, .identifier(auto: true))
                     .field("data", .data, .required)
                     .create()
             }
 
-            func revert(on database: Database) -> EventLoopFuture<Void> {
-                return database.schema("foos").delete()
+            func revert(on database: any Database) -> EventLoopFuture<Void> {
+                database.schema("foos").delete()
             }
         }
 
@@ -91,15 +91,15 @@ final class FluentPostgresDriverTests: XCTestCase {
         }
 
         struct CreateOrganization: Migration {
-            func prepare(on database: Database) -> EventLoopFuture<Void> {
-                return database.schema("orgs")
+            func prepare(on database: any Database) -> EventLoopFuture<Void> {
+                database.schema("orgs")
                     .field("id", .int, .identifier(auto: true))
                     .field("disabled", .bool, .required)
                     .create()
             }
 
-            func revert(on database: Database) -> EventLoopFuture<Void> {
-                return database.schema("orgs").delete()
+            func revert(on database: any Database) -> EventLoopFuture<Void> {
+                database.schema("orgs").delete()
             }
         }
 
@@ -123,8 +123,8 @@ final class FluentPostgresDriverTests: XCTestCase {
         jsonDecoder.dateDecodingStrategy = .iso8601
 
         self.dbs.use(.testPostgres(subconfig: "A",
-            encoder: PostgresDataEncoder(json: jsonEncoder),
-            decoder: PostgresDataDecoder(json: jsonDecoder)
+            encodingContext: .init(jsonEncoder: jsonEncoder),
+            decodingContext: .init(jsonDecoder: jsonDecoder)
         ), as: .iso8601)
         let db = self.dbs.database(
             .iso8601,
@@ -167,14 +167,14 @@ final class FluentPostgresDriverTests: XCTestCase {
     var benchmarker: FluentBenchmarker {
         return .init(databases: self.dbs)
     }
-    var eventLoopGroup: EventLoopGroup!
+    var eventLoopGroup: (any EventLoopGroup)!
     var threadPool: NIOThreadPool!
     var dbs: Databases!
-    var db: Database {
+    var db: any Database {
         self.benchmarker.database
     }
-    var postgres: PostgresDatabase {
-        self.db as! PostgresDatabase
+    var postgres: any PostgresDatabase {
+        self.db as! any PostgresDatabase
     }
     
     override func setUpWithError() throws {
@@ -189,12 +189,12 @@ final class FluentPostgresDriverTests: XCTestCase {
         self.dbs.use(.testPostgres(subconfig: "B"), as: .b)
 
         let a = self.dbs.database(.a, logger: Logger(label: "test.fluent.a"), on: self.eventLoopGroup.any())
-        _ = try (a as! PostgresDatabase).query("drop schema public cascade").wait()
-        _ = try (a as! PostgresDatabase).query("create schema public").wait()
+        _ = try (a as! any PostgresDatabase).query("drop schema public cascade").wait()
+        _ = try (a as! any PostgresDatabase).query("create schema public").wait()
 
         let b = self.dbs.database(.b, logger: Logger(label: "test.fluent.b"), on: self.eventLoopGroup.any())
-        _ = try (b as! PostgresDatabase).query("drop schema public cascade").wait()
-        _ = try (b as! PostgresDatabase).query("create schema public").wait()
+        _ = try (b as! any PostgresDatabase).query("drop schema public cascade").wait()
+        _ = try (b as! any PostgresDatabase).query("create schema public").wait()
     }
 
     override func tearDownWithError() throws {
@@ -259,15 +259,15 @@ final class EventStringlyTyped: Model {
 }
 
 struct EventMigration: Migration {
-    func prepare(on database: Database) -> EventLoopFuture<Void> {
-        return database.schema(Event.schema)
+    func prepare(on database: any Database) -> EventLoopFuture<Void> {
+        database.schema(Event.schema)
             .field("id", .int, .identifier(auto: true))
             .field("metadata", .json, .required)
             .create()
     }
 
-    func revert(on database: Database) -> EventLoopFuture<Void> {
-        return database.schema(Event.schema).delete()
+    func revert(on database: any Database) -> EventLoopFuture<Void> {
+        database.schema(Event.schema).delete()
     }
 }
 
@@ -290,8 +290,8 @@ enum Foobar: String, Codable {
 }
 
 struct EventWithFooMigration: Migration {
-    func prepare(on database: Database) -> EventLoopFuture<Void> {
-        return database.enum(Foobar.schema).read()
+    func prepare(on database: any Database) -> EventLoopFuture<Void> {
+        database.enum(Foobar.schema).read()
             .flatMap { foobar in
                 database.schema(EventWithFoo.schema)
                     .id()
@@ -300,36 +300,36 @@ struct EventWithFooMigration: Migration {
             }
     }
 
-    func revert(on database: Database) -> EventLoopFuture<Void> {
-        return database.schema(EventWithFoo.schema).delete()
+    func revert(on database: any Database) -> EventLoopFuture<Void> {
+        database.schema(EventWithFoo.schema).delete()
     }
 }
 
 struct EnumMigration: Migration {
-    func prepare(on database: Database) -> EventLoopFuture<Void> {
-        return database.enum(Foobar.schema)
+    func prepare(on database: any Database) -> EventLoopFuture<Void> {
+        database.enum(Foobar.schema)
             .case("foo")
             .case("bar")
             .create()
             .transform(to: ())
     }
 
-    func revert(on database: Database) -> EventLoopFuture<Void> {
-        return database.enum(Foobar.schema).delete()
+    func revert(on database: any Database) -> EventLoopFuture<Void> {
+        database.enum(Foobar.schema).delete()
     }
 }
 
 struct EnumAddMultipleCasesMigration: Migration {
-    func prepare(on database: Database) -> EventLoopFuture<Void> {
-        return database.enum(Foobar.schema)
+    func prepare(on database: any Database) -> EventLoopFuture<Void> {
+        database.enum(Foobar.schema)
             .case("baz")
             .case("qux")
             .update()
             .transform(to: ())
     }
 
-    func revert(on database: Database) -> EventLoopFuture<Void> {
-        return database.enum(Foobar.schema)
+    func revert(on database: any Database) -> EventLoopFuture<Void> {
+        database.enum(Foobar.schema)
             .deleteCase("baz")
             .deleteCase("qux")
             .update()
@@ -340,7 +340,7 @@ struct EnumAddMultipleCasesMigration: Migration {
 let isLoggingConfigured: Bool = {
     LoggingSystem.bootstrap { label in
         var handler = StreamLogHandler.standardOutput(label: label)
-        handler.logLevel = env("LOG_LEVEL").flatMap { Logger.Level(rawValue: $0) } ?? .debug
+        handler.logLevel = env("LOG_LEVEL").flatMap { Logger.Level(rawValue: $0) } ?? .info
         return handler
     }
     return true

--- a/Tests/FluentPostgresDriverTests/FluentPostgresDriverTests.swift
+++ b/Tests/FluentPostgresDriverTests/FluentPostgresDriverTests.swift
@@ -208,17 +208,19 @@ final class FluentPostgresDriverTests: XCTestCase {
 extension DatabaseConfigurationFactory {
     static func testPostgres(
         subconfig: String,
-        encoder: PostgresDataEncoder = .init(), decoder: PostgresDataDecoder = .init()
+        encodingContext: PostgresEncodingContext<some PostgresJSONEncoder> = .default,
+        decodingContext: PostgresDecodingContext<some PostgresJSONDecoder> = .default
     ) -> DatabaseConfigurationFactory {
-        let baseSubconfig = PostgresConfiguration(
+        let baseSubconfig = SQLPostgresConfiguration(
             hostname: env("POSTGRES_HOSTNAME_\(subconfig)") ?? "localhost",
-            port: env("POSTGRES_PORT_\(subconfig)").flatMap(Int.init) ?? PostgresConfiguration.ianaPortNumber,
+            port: env("POSTGRES_PORT_\(subconfig)").flatMap(Int.init) ?? SQLPostgresConfiguration.ianaPortNumber,
             username: env("POSTGRES_USER_\(subconfig)") ?? "test_username",
             password: env("POSTGRES_PASSWORD_\(subconfig)") ?? "test_password",
-            database: env("POSTGRES_DB_\(subconfig)") ?? "test_database"
+            database: env("POSTGRES_DB_\(subconfig)") ?? "test_database",
+            tls: try! .prefer(.init(configuration: .makeClientConfiguration()))
         )
         
-        return .postgres(configuration: baseSubconfig, connectionPoolTimeout: .seconds(30), encoder: encoder, decoder: decoder)
+        return .postgres(configuration: baseSubconfig, connectionPoolTimeout: .seconds(30), encodingContext: encodingContext, decodingContext: decodingContext)
     }
 }
 

--- a/Tests/FluentPostgresDriverTests/FluentPostgresTransactionControlTests.swift
+++ b/Tests/FluentPostgresDriverTests/FluentPostgresTransactionControlTests.swift
@@ -6,20 +6,19 @@ import XCTest
 import PostgresKit
 
 final class FluentPostgresTransactionControlTests: XCTestCase {
-    
     func testRollback() throws {
         do {
             try self.db.withConnection { db -> EventLoopFuture<Void> in
-                (db as! TransactionControlDatabase).beginTransaction().flatMap { () -> EventLoopFuture<Void> in
+                (db as! any TransactionControlDatabase).beginTransaction().flatMap { () -> EventLoopFuture<Void> in
                     let todo1 = Todo(title: "Test")
                     return todo1.save(on: db)
                 }.flatMap { () -> EventLoopFuture<Void> in
                     let duplicate = Todo(title: "Test")
                     return duplicate.create(on: db)
                         .flatMap {
-                            (db as! TransactionControlDatabase).commitTransaction()
+                            (db as! any TransactionControlDatabase).commitTransaction()
                         }.flatMapError { (e: Error) -> EventLoopFuture<Void> in
-                            return (db as! TransactionControlDatabase).rollbackTransaction()
+                            return (db as! any TransactionControlDatabase).rollbackTransaction()
                                 .flatMap { db.eventLoop.makeFailedFuture(e) }
                         }
                 }
@@ -35,10 +34,10 @@ final class FluentPostgresTransactionControlTests: XCTestCase {
         XCTAssertEqual(count2, 0)
     }
     
-    var eventLoopGroup: EventLoopGroup!
+    var eventLoopGroup: (any EventLoopGroup)!
     var threadPool: NIOThreadPool!
     var dbs: Databases!
-    var db: Database!
+    var db: (any Database)!
     
     override func setUpWithError() throws {
         try super.setUpWithError()
@@ -79,16 +78,16 @@ final class FluentPostgresTransactionControlTests: XCTestCase {
     }
     
     struct CreateTodo: Migration {
-        func prepare(on database: Database) -> EventLoopFuture<Void> {
-            return database.schema("todos")
+        func prepare(on database: any Database) -> EventLoopFuture<Void> {
+            database.schema("todos")
                 .id()
                 .field("title", .string, .required)
                 .unique(on: "title")
                 .create()
         }
 
-        func revert(on database: Database) -> EventLoopFuture<Void> {
-            return database.schema("todos").delete()
+        func revert(on database: any Database) -> EventLoopFuture<Void> {
+            database.schema("todos").delete()
         }
     }
 }

--- a/Tests/FluentPostgresDriverTests/FluentPostgresTransactionControlTests.swift
+++ b/Tests/FluentPostgresDriverTests/FluentPostgresTransactionControlTests.swift
@@ -25,7 +25,7 @@ final class FluentPostgresTransactionControlTests: XCTestCase {
                 }
             }.wait()
             XCTFail("Expected error but none was thrown")
-        } catch PostgresError.server(let e) where e.fields[.sqlState] == "23505" {
+        } catch let error as PSQLError where error.code == .server && error.serverInfo?[.sqlState] == "23505" {
             // ignore
         } catch {
             XCTFail("Expected SQL state 23505 but got \(error)")


### PR DESCRIPTION
[PostgresKit 2.11.0](https://github.com/vapor/postgres-kit/releases/tag/2.11.0) heavily revamped PostgresKit to take full (or near to it) advantage of the modern PostgresNIO APIs. These changes do the same for FluentPostgresDriver, including adopting the revisions made to PostgresKit's API. This incidentally results in a significant improvement in the layering of the three packages, with FluentPostgresDriver now relying almost entirely on PostgresKit alone rather than needing to separately know details of PostgresNIO (with one or two exceptions). The end result is much cleaner code and moderate performance improvements.

Swift 5.7 or later is now required.

Users who previously specified custom `PostgresDataEncoder` and/or `PostgresDataDecoder` instances in their database configurations will begin receiving deprecation warnings; the replacements are PostgresNIO's `PostgresEncodingContext` and `PostgresDecodingContext`:

```swift
let postgresEncoder = PostgresDataEncoder(json: JSONEncoder()) // deprecated
let postgresEncodingContext = PostgresEncodingContext(jsonEncoder: JSONEncoder()) // new

let defaultPostgresEncoder = PostgresDataEncoder() // deprecated
let defaultPostgresEncodingContext = PostgresEncodingContext.default // new

let postgresDecoder = PostgresDataDecoder(json: JSONDecoder()) // deprecated
let postgresDecodingContext = PostgresDecodingContext(jsonDecoder: JSONDecoder()) // new

let defaultPostgresDecoder = PostgresDataDecoder() // deprecated
let defaultPostgresDecodingContext = PostgresDecodingContext.default // new
```