### PR TITLE
Update required versions of dependencies

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,9 +13,9 @@ let package = Package(
         .library(name: "FluentPostgresDriver", targets: ["FluentPostgresDriver"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/vapor/async-kit.git", from: "1.17.0"),
-        .package(url: "https://github.com/vapor/fluent-kit.git", from: "1.43.0"),
-        .package(url: "https://github.com/vapor/postgres-kit.git", from: "2.11.4"),
+        .package(url: "https://github.com/vapor/async-kit.git", from: "1.19.0"),
+        .package(url: "https://github.com/vapor/fluent-kit.git", from: "1.48.4"),
+        .package(url: "https://github.com/vapor/postgres-kit.git", from: "2.13.4"),
     ],
     targets: [
         .target(
@@ -42,6 +42,4 @@ let package = Package(
 var swiftSettings: [SwiftSetting] { [
     .enableUpcomingFeature("ConciseMagicFile"),
     .enableUpcomingFeature("ForwardTrailingClosures"),
-    .enableUpcomingFeature("DisableOutwardActorInference"),
-    .enableExperimentalFeature("StrictConcurrency=complete"),
 ] }

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -13,9 +13,9 @@ let package = Package(
         .library(name: "FluentPostgresDriver", targets: ["FluentPostgresDriver"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/vapor/async-kit.git", from: "1.17.0"),
-        .package(url: "https://github.com/vapor/fluent-kit.git", from: "1.43.0"),
-        .package(url: "https://github.com/vapor/postgres-kit.git", from: "2.11.4"),
+        .package(url: "https://github.com/vapor/async-kit.git", from: "1.19.0"),
+        .package(url: "https://github.com/vapor/fluent-kit.git", from: "1.48.4"),
+        .package(url: "https://github.com/vapor/postgres-kit.git", from: "2.13.4"),
     ],
     targets: [
         .target(

--- a/Sources/FluentPostgresDriver/FluentPostgresConfiguration.swift
+++ b/Sources/FluentPostgresDriver/FluentPostgresConfiguration.swift
@@ -99,7 +99,7 @@ fileprivate struct FakeSendable<T>: @unchecked Sendable { let wrappedValue: T }
 
 /// We'd like to just default the context parameters of the "actual" method. Unfortunately, there are a few
 /// cases involving the UNIX domain socket initalizer where usage can resolve to either the new
-/// ``SQLPostgresConfiguration``-based method or the deprecated ``PostgresConfiguration``-based method, with no
+/// `SQLPostgresConfiguration`-based method or the deprecated `PostgresConfiguration`-based method, with no
 /// obvious way to disambiguate which to call. Because the context parameters are generic, if they are defaulted,
 /// the compiler resolves the ambiguity in favor of the deprecated method (which has no generic parameters).
 /// However, by adding the non-defaulted-parameter variant which takes neither context, we've provided a version


### PR DESCRIPTION
Helps avoid users getting into states where things won't build. Also fixes a DocC warning.