### PR TITLE
Shut down the driver's connection pool safely

### DIFF
--- a/Sources/FluentPostgresDriver/FluentPostgresDriver.swift
+++ b/Sources/FluentPostgresDriver/FluentPostgresDriver.swift
@@ -25,6 +25,6 @@ struct _FluentPostgresDriver<E: PostgresJSONEncoder, D: PostgresJSONDecoder>: Da
     }
     
     func shutdown() {
-        self.pool.shutdown()
+        try? self.pool.syncShutdownGracefully()
     }
 }


### PR DESCRIPTION
Specifically, don't use the soft-deprecated AsyncKit API that calls `EventLoopFuture.wait()` internally; use the one that at least does it with Dispatch (best we can do without changing Fluent's driver interface).